### PR TITLE
Update Sony store

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ priceFinder.findItemDetails(uri, function(err, itemDetails) {
     console.log(itemDetails.category); // Mobile Apps
 });
 
-// PixelJunk Monsters  (from Sony Entertainment Network Store)
-uri = "https://store.sonyentertainmentnetwork.com/#!/en-us/games/pixeljunk-monsters/cid=UP9000-NPUA80108_00-PJMONSTSFULL0001";
+// PixelJunk Monsters  (from Sony Entertainment Network / Playstation Store)
+uri = "https://store.playstation.com/#!/en-us/games/pixeljunk-monsters/cid=UP9000-NPUA80108_00-PJMONSTSFULL0001";
 priceFinder.findItemDetails(uri, function(err, itemDetails) {
     console.log(itemDetails.price);    // 9.99
     console.log(itemDetails.name);     // PixelJunk™ Monsters

--- a/lib/sites/sony-entertainment-network-store.js
+++ b/lib/sites/sony-entertainment-network-store.js
@@ -17,7 +17,7 @@ function SonyEntertainmentNetworkStoreSite(uri) {
     };
 
     this.getURIForPageData = function() {
-        var apiURI = "https://store.sonyentertainmentnetwork.com/store/api/chihiro/00_09_000/container/US/en/999/";
+        var apiURI = "https://store.playstation.com/store/api/chihiro/00_09_000/container/US/en/999/";
         // add the CID of the URI to the API URI
         apiURI = apiURI + this._uri.slice(this._uri.indexOf("cid=") + "cid=".length);
 
@@ -96,7 +96,8 @@ function SonyEntertainmentNetworkStoreSite(uri) {
 }
 
 SonyEntertainmentNetworkStoreSite.isSite = function(uri) {
-    if (uri.indexOf("store.sonyentertainmentnetwork.com") > -1) {
+    if ((uri.indexOf("store.sonyentertainmentnetwork.com") > -1) ||
+        (uri.indexOf("store.playstation.com") > -1)) {
         return true;
     } else {
         return false;

--- a/test/e2e/sony-entertainment-network-store-uris-test.js
+++ b/test/e2e/sony-entertainment-network-store-uris-test.js
@@ -26,7 +26,7 @@ describe("price-finder for Sony Entertainment Network Store URIs", function() {
     // Video Games
     describe("testing a Video Game item", function() {
         // PixelJunk™ Monsters
-        var uri = "https://store.sonyentertainmentnetwork.com/#!/en-us/games/pixeljunk-monsters/cid=UP9000-NPUA80108_00-PJMONSTSFULL0001";
+        var uri = "https://store.playstation.com/#!/en-us/games/pixeljunk-monsters/cid=UP9000-NPUA80108_00-PJMONSTSFULL0001";
 
         it("should respond with a price for findItemPrice()", function(done) {
             priceFinder.findItemPrice(uri, function(err, price) {

--- a/test/unit/sites/sony-entertainment-network-store-test.js
+++ b/test/unit/sites/sony-entertainment-network-store-test.js
@@ -5,7 +5,8 @@ var SonyENSSite = require("../../../lib/sites/sony-entertainment-network-store")
     siteUtils = require("../../../lib/site-utils");
 
 var VALID_URI = "https://store.sonyentertainmentnetwork.com/#!/en-us/games/my-game/cid=123ABC",
-    VALID_API_URL = "https://store.sonyentertainmentnetwork.com/store/api/chihiro/00_09_000/container/US/en/999/123ABC",
+    VALID_URI_2 = "https://store.playstation.com/#!/en-us/games/my-game/cid=123ABC",
+    VALID_API_URL = "https://store.playstation.com/store/api/chihiro/00_09_000/container/US/en/999/123ABC",
     INVALID_URI = "http://www.bad.com/123/product";
 
 describe("The Sony Entertainment Network Store Site", function() {
@@ -17,6 +18,10 @@ describe("The Sony Entertainment Network Store Site", function() {
     describe("isSite() function", function() {
         it("should return true for a correct site", function() {
             expect(SonyENSSite.isSite(VALID_URI)).toBeTruthy();
+        });
+
+        it("should return true for a correct (alternate) site", function() {
+            expect(SonyENSSite.isSite(VALID_URI_2)).toBeTruthy();
         });
 
         it("should return false for a bad site", function() {


### PR DESCRIPTION
The Sony store has recently changed it’s URL’s from `sonyentertainmentnetwork` to `playstation`.  URL redirects exist for legacy URLs, but we should support both forms.  So update the site to support both the old and new URL, and from here on generate new URLs for the store.