### PR TITLE
Update jshint files, add Grunt for testing

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,10 +1,23 @@
 {
-    "globalstrict": true,
-    "globals": {
-        "module": false,
-        "require": false,
-        "console": false,
-        "__dirname": false,
-        "setTimeout": false
-    }
+    "node": true,       // Enable globals available when code is running inside of the NodeJS runtime environment.
+    "eqeqeq": true,     // Require triple equals i.e. `===`.
+    "immed": true,      // Require immediate invocations to be wrapped in parens e.g. `( function(){}() );`
+    "newcap": true,     // Require capitalization of all constructor functions e.g. `new F()`.
+    "undef": true,      // Require all non-global variables be declared before they are used.
+    "latedef": true,    // Prohibit variable use before definition.
+    "unused": "vars",   // Warn unused variables.
+    "strict": true,     // Require `use strict` pragma in every file.
+    "trailing": true,   // Prohibit trailing whitespaces.
+    "expr": true,       // let expressions be statements to appease chai.expect
+    "globals": {        // Globals variables.
+    },
+    "predef": [         // Extra globals.
+        "require",
+        "exports",
+        "module",
+        "__dirname",
+        "setTimeout"
+    ],
+    "indent": 4,        // Specify indentation spacing
+    "devel": true       // Allow development statements e.g. `console.log();`.
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,39 @@
+"use strict";
+
+module.exports = function(grunt) {
+    grunt.initConfig({
+        jshint: {
+            files: [
+                "**/*.js"
+            ],
+            options: {
+                ignores: [
+                    "node_modules/**"
+                ],
+                jshintrc: true
+            }
+        },
+        jasmine_nodejs: {
+            options: {
+                specNameSuffix: "test.js",
+                reporters: {
+                    console: {
+                        colors: true,
+                        cleanStack: true,
+                        verbosity: true,
+                        listStyle: "indent",
+                        activity: false
+                    }
+                }
+            },
+            all: {
+                specs: ["test/unit/**"]
+            }
+        }
+    });
+
+    // load all the grunt tasks at once
+    require("load-grunt-tasks")(grunt);
+
+    grunt.registerTask("test", ["jshint", "jasmine_nodejs"]);
+};

--- a/lib/sites/crutchfield.js
+++ b/lib/sites/crutchfield.js
@@ -62,7 +62,7 @@ function Crutchfield(uri) {
     };
 
     this.findNameOnPage = function($, category) {
-        var name, citeIndex;
+        var name;
 
         name = $("h1.productTitleMain").text();
         if (!name || name.length < 1) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "main": "./lib/price-finder",
     "scripts": {
         "prepublish": "npm prune",
-        "test": "jasmine-node --test-dir test/unit --matchall --color --verbose",
+        "test": "grunt test",
         "test-watch": "jasmine-node --test-dir test/unit --matchall --color --autotest --watch lib",
         "test-e2e": "jasmine-node --test-dir test/e2e --matchall --color --verbose --noStack"
     },
@@ -52,6 +52,11 @@
     },
     "devDependencies": {
         "jasmine-node": "^1.14.3",
-        "rewire": "^2.0.0"
+        "rewire": "^2.0.0",
+        "grunt-jasmine-nodejs": "^1.4.3",
+        "grunt-cli": "^0.1.13",
+        "grunt": "^0.4.5",
+        "grunt-contrib-jshint": "^0.11.2",
+        "load-grunt-tasks": "^3.2.0"
     }
 }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,12 +1,16 @@
 {
-    "globalstrict": true,
-    "globals": {
-        "require": false,
-        "describe": false,
-        "beforeEach": false,
-        "afterEach": false,
-        "it": false,
-        "expect": false,
-        "jasmine": false
-    }
+    "extends": "../.jshintrc",
+    "globals": {        // Globals variables.
+        "jasmine": true
+    },
+    "predef": [         // Extra globals.
+        "describe",
+        "before",
+        "beforeEach",
+        "after",
+        "afterEach",
+        "it",
+        "expect",
+        "inject"
+    ]
 }

--- a/test/unit/sites/sony-entertainment-network-store-test.js
+++ b/test/unit/sites/sony-entertainment-network-store-test.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var SonyENSSite = require("../../../lib/sites/sony-entertainment-network-store"),
-    cheerio = require("cheerio"),
     siteUtils = require("../../../lib/site-utils");
 
 var VALID_URI = "https://store.sonyentertainmentnetwork.com/#!/en-us/games/my-game/cid=123ABC",


### PR DESCRIPTION
Update the `.jshintrc` files to be a bit more strict, and in doing so, clean up the code where necessary.  To automate this process, add Grunt support which now runs the tests (but first runs jshint).