### PR TITLE
Improve error handling for BestBuy site

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The following options are configurable:
     code will sleep prior to re-issuing the request. Defaults to
     <code>1000</code> (ms).</li>
     <li><code>keys</code> : An object of API keys required by services dependent upon keys. The following is the complete list of API services requiring keys:
-    <table><thead><tr><th>Service</th><th>Object Key</th><th>Environment Variable</th></tr></thead>
+    <table><thead><tr><th>Service</th><th>Object Key</th><th>Environment Variable Override</th></tr></thead>
     <tbody>
         <tr>
             <td><a href="https://developer.bestbuy.com">Best Buy</a></td><td><code>bestbuy</code></td><td><code>BESTBUY_KEY</code></td></tr>

--- a/lib/sites/best-buy.js
+++ b/lib/sites/best-buy.js
@@ -4,6 +4,8 @@ var siteUtils = require("../site-utils"),
     logger = require("../logger")();
 
 function BestBuySite(uri, config) {
+    var errorMessage;
+
     // error check to make sure this is a valid uri for Best Buy
     if (!BestBuySite.isSite(uri)) {
         throw new Error("invalid uri for Best Buy: " + uri);
@@ -11,25 +13,38 @@ function BestBuySite(uri, config) {
 
     this._uri = uri;
 
+    // attempt to find the API key
+    if (config.keys && config.keys.bestbuy) {
+        this.api_key = config.keys.bestbuy;
+    }
+    // allow the environment variable to override the config
+    if (!!process.env.BESTBUY_KEY) {
+        this.api_key = process.env.BESTBUY_KEY;
+    }
+    // if we still don't have an API key, abort!
+    if (!this.api_key) {
+        errorMessage = "Best Buy cannot be called unless an API key is provided";
+        logger.error(errorMessage);
+        throw new Error(errorMessage);
+    }
+
     this.isJSON = function() {
         return true;
     };
 
     this.getURIForPageData = function() {
-        var api_key = process.env.BESTBUY_KEY;
-        if (config.keys && config.keys.bestbuy) {
-            api_key = config.keys.bestbuy;
-        }
-        if (!api_key) {
-            logger.error("Best Buy cannot be called unless an API key is provided");
-            return null;
-        }
-        var sku = /skuId=(\d+)/.exec(this._uri);
+        var sku;
+
+        sku = /skuId=(\d+)/.exec(this._uri);
         if (!sku || !sku[1]) {
             logger.error("Could not detect the SKU from the URL");
             return null;
         }
-        return "https://api.remix.bestbuy.com/v1/products/" + sku[1] + ".json?show=sku,name,salePrice,categoryPath&apiKey=" + api_key;
+
+        return "https://api.remix.bestbuy.com/v1/products/" +
+            sku[1] +
+            ".json?show=sku,name,salePrice,categoryPath&apiKey=" +
+            this.api_key;
     };
 
     this.findPriceOnPage = function(pageData) {

--- a/test/unit/sites/best-buy-test.js
+++ b/test/unit/sites/best-buy-test.js
@@ -30,6 +30,28 @@ describe("The Best Buy Site", function() {
         }).toThrow();
     });
 
+    it("should throw an exception trying to create a new BestBuySite without an API key", function() {
+        expect(function() {
+            new BestBuySite(VALID_URI, {});
+        }).toThrow();
+    });
+
+    describe("with an API key in the environment", function() {
+        beforeEach(function() {
+            process.env.BESTBUY_KEY = "123";
+        });
+
+        afterEach(function() {
+            process.env.BESTBUY_KEY = "";
+        });
+
+        it("should throw an exception trying to create a new BestBuySite without an API key", function() {
+            expect(function() {
+                new BestBuySite(VALID_URI, {});
+            }).not.toThrow();
+        });
+    });
+
     describe("a new Best Buy Site", function() {
         var bestBuy;
 


### PR DESCRIPTION
To avoid the case that the user does not have an API key, and they request a price for a BestBuy URL, the error that previously was returned concerned not having a URI to make the page request.  This was because the API key lookup was within the `getURIForPageData` function.

This commit moves that into the constructor of the BestBuy site, so that if the API key is not available on instantiation, we throw an error and include within it the reason why (no API key).  The `getURIForPageData` function can then generate the URI without worrying if the API key exists or not.

Also, change the logic so that the environment variable overrides the configuration.  This allows us the ability to change things in production without a code change.  Mark this as so in the readme.