### PR TITLE
Fix Amazon books price selector

### DIFF
--- a/lib/sites/amazon.js
+++ b/lib/sites/amazon.js
@@ -33,7 +33,7 @@ function AmazonSite(uri) {
             ".buyNewOffers .rentPrice",
             "#buybox .a-color-price",
             "#buybox_feature_div .a-button-primary .a-text-bold",
-            "#newOfferAccordionRow .header-price"
+            "#addToCart .header-price"
         ];
 
         // find the price on the page


### PR DESCRIPTION
Change the selector to something a bit higher level, in the hopes that it works longer.

This closes https://github.com/dylants/price-finder/issues/13.