### PR TITLE
Fix eBags price selector

### DIFF
--- a/lib/sites/ebags.js
+++ b/lib/sites/ebags.js
@@ -25,7 +25,7 @@ function EBagsSite(uri) {
 
         // the various ways we can find the price on an ebags page
         selectors = [
-            "#divPricing h2[itemprop='price']"
+            "#divPricing *[itemprop='price']"
         ];
 
         // find the price on the page


### PR DESCRIPTION
Use a wildcard along with the `itemprop` selector instead of binding it to the `h2`.

This closes https://github.com/dylants/price-finder/issues/14.