### PR TITLE
Fix for Amazon books accordion

### DIFF
--- a/lib/sites/amazon.js
+++ b/lib/sites/amazon.js
@@ -33,7 +33,7 @@ function AmazonSite(uri) {
             ".buyNewOffers .rentPrice",
             "#buybox .a-color-price",
             "#buybox_feature_div .a-button-primary .a-text-bold",
-            "#addToCart .header-price"
+            "#addToCart #newOfferAccordionRow .header-price"
         ];
 
         // find the price on the page
@@ -47,8 +47,9 @@ function AmazonSite(uri) {
         }
 
         // get the number value (remove dollar sign)
+        logger.log("price string (pre-process): " + price);
         price = +(price.slice(1));
-        logger.log("price: " + price);
+        logger.log("price (post-process): " + price);
 
         return price;
     };


### PR DESCRIPTION
I’d really rather not include the accordion ID tag in the selector for the books, but Amazon has the same HTML structure for the used and new book price.  So include the new ID tag in the selector, and some additional logging to help determine the issue in the future.

This should close #21.