### PR TITLE
Node v4 support: update Travis CI versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
   - "0.10"
+  - "0.12"
   - "iojs"
+  - "4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ node_js:
   - "0.12"
   - "iojs"
   - "4"
+sudo: false


### PR DESCRIPTION
Add Node v4 to the list of Node versions run in the Travis CI test builds.  Everything else seems to work fine with Node v4.

This should close #20.