### PR TITLE
Support additional currencies (Amazon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ specific library to only enable a certain module). For example:
 The current supported sites, along with categories supported within each site,
 are listed below.
 
-* Amazon
+* Amazon (support for more than just .com)
     * Digital Music
     * Video Games
     * Mobile Apps

--- a/lib/site-utils.js
+++ b/lib/site-utils.js
@@ -5,7 +5,7 @@ var _ = require("lodash"),
     logger = require("./logger")();
 
 // Represents the various categories of an online item
-exports.categories = {
+exports.categories = Object.freeze({
     DIGITAL_MUSIC: "Digital Music",
     MUSIC: "Music",
     VIDEO_GAMES: "Video Games",
@@ -21,7 +21,7 @@ exports.categories = {
     HOME_AUDIO: "Home Audio",
     LUGGAGE: "Luggage",
     OTHER: "Other"
-};
+});
 
 /**
  * Finds content on a page, returning either the text or null.
@@ -48,17 +48,24 @@ exports.findContentOnPage = function($, selectors) {
     return null;
 };
 
+var DOLLAR_PREFIX = "$";
+var EURO_TEXT_PREFIX = "eur";
+var EURO_SYMBOL_PREFIX = "€";
+
 exports.processPrice = function(priceString) {
     var price;
 
-    logger.log("price string (pre-process): " + priceString);
+    priceString = priceString.toLowerCase();
+
+    logger.log("price string (lowercased): " + priceString);
 
     // currency specific processing
-    if (_.includes(priceString, "$")) {
-        logger.log("found $ in price, converting to number...");
+    if (_.includes(priceString, DOLLAR_PREFIX)) {
+        logger.log("found dollar in price, converting to number...");
         price = accounting.unformat(priceString);
-    } else if (_.includes(priceString, "EUR")) {
-        logger.log("found EUR in price, converting to number...");
+    } else if (_.includes(priceString, EURO_TEXT_PREFIX) ||
+        _.includes(priceString, EURO_SYMBOL_PREFIX)) {
+        logger.log("found euro in price, converting to number...");
         price = accounting.unformat(priceString, ",");
     } else {
         // unknown price type!!

--- a/lib/site-utils.js
+++ b/lib/site-utils.js
@@ -1,9 +1,11 @@
 "use strict";
 
-var logger = require("./logger")();
+var _ = require("lodash"),
+    accounting = require("accounting"),
+    logger = require("./logger")();
 
 // Represents the various categories of an online item
-module.exports.categories = {
+exports.categories = {
     DIGITAL_MUSIC: "Digital Music",
     MUSIC: "Music",
     VIDEO_GAMES: "Video Games",
@@ -28,7 +30,7 @@ module.exports.categories = {
  * @param  {Array} selectors  An array of selectors to search with
  * @return {String}           The content found (or null)
  */
-module.exports.findContentOnPage = function($, selectors) {
+exports.findContentOnPage = function($, selectors) {
     var i, content;
 
     logger.log("selectors: " + selectors);
@@ -36,7 +38,7 @@ module.exports.findContentOnPage = function($, selectors) {
     // loop until we find the content, or we exhaust our selectors
     for (i = 0; i < selectors.length; i++) {
         content = $(selectors[i]);
-        if (content && content.length > 0) {
+        if (!_.isEmpty(content)) {
             logger.log("found content with selector: " + selectors[i]);
             return content.text().trim();
         }
@@ -44,4 +46,26 @@ module.exports.findContentOnPage = function($, selectors) {
 
     // if we've not found anything, return null to signify that
     return null;
+};
+
+exports.processPrice = function(priceString) {
+    var price;
+
+    logger.log("price string (pre-process): " + priceString);
+
+    // currency specific processing
+    if (_.includes(priceString, "$")) {
+        logger.log("found $ in price, converting to number...");
+        price = accounting.unformat(priceString);
+    } else if (_.includes(priceString, "EUR")) {
+        logger.log("found EUR in price, converting to number...");
+        price = accounting.unformat(priceString, ",");
+    } else {
+        // unknown price type!!
+        logger.error("unknown price type, unable to process, returning -1");
+        price = -1;
+    }
+
+    logger.log("price (post-process): " + price);
+    return price;
 };

--- a/lib/sites/amazon.js
+++ b/lib/sites/amazon.js
@@ -46,10 +46,8 @@ function AmazonSite(uri) {
             return -1;
         }
 
-        // get the number value (remove dollar sign)
-        logger.log("price string (pre-process): " + price);
-        price = +(price.slice(1));
-        logger.log("price (post-process): " + price);
+        // process the price string
+        price = siteUtils.processPrice(price);
 
         return price;
     };
@@ -122,7 +120,9 @@ function AmazonSite(uri) {
 }
 
 AmazonSite.isSite = function(uri) {
-    if (uri.indexOf("amazon.com") > -1) {
+    // (attempt) to support more countries than just amazon.com
+    // we'll see how many we can actually support...
+    if (uri.indexOf("www.amazon.") > -1) {
         return true;
     } else {
         return false;

--- a/package.json
+++ b/package.json
@@ -44,9 +44,11 @@
         "test-e2e": "DEBUG=price-finder* jasmine-node --test-dir test/e2e --matchall --color --verbose --noStack"
     },
     "dependencies": {
+        "accounting": "^0.4.0",
         "async": "^1.4.2",
         "cheerio": "^0.19.0",
         "debug-caller": "^2.0.0",
+        "lodash": "^3.0.0",
         "request": "^2.34.0",
         "xtend": "^4.0.0"
     },

--- a/test/unit/site-utils-test.js
+++ b/test/unit/site-utils-test.js
@@ -20,14 +20,14 @@ describe("The Site Utils", function() {
         expect(keys.length).toBeGreaterThan(0);
     });
 
-    describe("with a populated page", function() {
+    describe("findContentOnPage() with a populated page", function() {
         var $;
 
         beforeEach(function() {
             $ = cheerio.load("<div id='price-tag'>$9.99</div>");
         });
 
-        it("findContentOnPage() should return the price given the correct selector", function() {
+        it("should return the price given the correct selector", function() {
             var selectors, price;
 
             selectors = [
@@ -39,7 +39,7 @@ describe("The Site Utils", function() {
             expect(price).toEqual("$9.99");
         });
 
-        it("findContentOnPage() should return null given incorrect selector", function() {
+        it("should return null given incorrect selector", function() {
             var selectors, price;
 
             selectors = [
@@ -49,6 +49,20 @@ describe("The Site Utils", function() {
             price = siteUtils.findContentOnPage($, selectors);
 
             expect(price).toEqual(null);
+        });
+    });
+
+    describe("processPrice()", function() {
+        it("should process $ price correctly", function() {
+            expect(siteUtils.processPrice("$3.99")).toEqual(3.99);
+        });
+
+        it("should process EUR price correctly", function() {
+            expect(siteUtils.processPrice("EUR 79,40")).toEqual(79.40);
+        });
+
+        it("should process an unknown price correctly", function() {
+            expect(siteUtils.processPrice("hey, how are you?")).toEqual(-1);
         });
     });
 });

--- a/test/unit/site-utils-test.js
+++ b/test/unit/site-utils-test.js
@@ -20,6 +20,12 @@ describe("The Site Utils", function() {
         expect(keys.length).toBeGreaterThan(0);
     });
 
+    it("should have some known categories", function() {
+        expect(siteUtils.categories.MUSIC).toEqual("Music");
+        expect(siteUtils.categories.VIDEO_GAMES).toEqual("Video Games");
+        expect(siteUtils.categories.BOOKS).toEqual("Books");
+    });
+
     describe("findContentOnPage() with a populated page", function() {
         var $;
 
@@ -59,6 +65,18 @@ describe("The Site Utils", function() {
 
         it("should process EUR price correctly", function() {
             expect(siteUtils.processPrice("EUR 79,40")).toEqual(79.40);
+        });
+
+        it("should process eur price correctly", function() {
+            expect(siteUtils.processPrice("eur 79,40")).toEqual(79.40);
+        });
+
+        it("should process Euros price correctly", function() {
+            expect(siteUtils.processPrice("Euros 79,40")).toEqual(79.40);
+        });
+
+        it("should process € price correctly", function() {
+            expect(siteUtils.processPrice("€ 79,40")).toEqual(79.40);
         });
 
         it("should process an unknown price correctly", function() {


### PR DESCRIPTION
What prompted this was issue #19, which requested Amazon support for additional sites other than “.com”.  In testing of the amazon.fr site, the main check done in `isSite` failed because of the restriction for “.com”.  Loosening this allowed price finder to locate the correct name, but unable to locate the price because of the currency difference.

This commit adds the `accounting` module which gives us the ability to pull the number value from a variety of currencies.  We’ve pulled the logic out of `amazon.js` and into a helper library, `site-utils.js`. Within here, perform an initial check to see which currency type we’re looking at, and then use `accounting` to find the number value, and return it to the user.

With this change the test url provided in the issue returns the correct name and number value for price, but the category is not found.  This seems like a good first step though…