### PR TITLE
Add support for Nintendo.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ are listed below.
     * Video Games
 * eBags
     * Luggage
+* Nintendo
+    * Video Games
 
 Don't see your site listed? Please consider [contributing](#contributing) to the project!
 

--- a/lib/sites/nintendo.js
+++ b/lib/sites/nintendo.js
@@ -1,0 +1,76 @@
+"use strict";
+
+var _ = require("lodash"),
+    siteUtils = require("../site-utils"),
+    logger = require("../logger")();
+
+function NintendoSite(uri) {
+
+    // error check to make sure this is a valid uri for Nintendo
+    if (!NintendoSite.isSite(uri)) {
+        throw new Error("invalid uri for Nintendo: " + uri);
+    }
+
+    this._uri = uri;
+
+    this.getURIForPageData = function() {
+        return this._uri;
+    };
+
+    this.isJSON = function() {
+        return false;
+    };
+
+    this.findPriceOnPage = function($) {
+        var price;
+
+        price = $("*[itemprop='price']").text();
+
+        if (!price) {
+            logger.error("price was not found on nintendo page, uri: " + this._uri);
+            return -1;
+        }
+        price = price.trim();
+
+        // process the price string
+        price = siteUtils.processPrice(price);
+
+        return price;
+    };
+
+    this.findCategoryOnPage = function($) {
+        var category;
+
+        // Nintendo only has video games, so hard code it
+        category = siteUtils.categories.VIDEO_GAMES;
+
+        logger.log("category: " + category);
+
+        return category;
+    };
+
+    this.findNameOnPage = function($, category) {
+        var name;
+
+        name = $("h1[itemprop='name']").text();
+
+        if (!name) {
+            logger.error("name not found on nintendo page, uri: " + this._uri);
+            return null;
+        }
+
+        logger.log("name: " + name);
+
+        return name;
+    };
+}
+
+NintendoSite.isSite = function(uri) {
+    if (_.contains(uri, "www.nintendo.com")) {
+        return true;
+    } else {
+        return false;
+    }
+};
+
+module.exports = NintendoSite;

--- a/test/e2e/nintendo-uris-test.js
+++ b/test/e2e/nintendo-uris-test.js
@@ -1,0 +1,79 @@
+"use strict";
+
+// set the timeout of these tests to 10 seconds
+jasmine.getEnv().defaultTimeoutInterval = 10000;
+
+var PriceFinder = require("../../lib/price-finder"),
+    priceFinder = new PriceFinder();
+
+function verifyPrice(price) {
+    expect(price).toBeDefined();
+    // we can't guarantee the price, so just make sure it's a number
+    // that's more than -1
+    expect(price).toBeGreaterThan(-1);
+}
+
+function verifyName(actualName, expectedName) {
+    expect(actualName).toEqual(expectedName);
+}
+
+function verifyCategory(actualCategory, expectedCategory) {
+    expect(actualCategory).toEqual(expectedCategory);
+}
+
+describe("price-finder for Nintendo URIs", function() {
+
+    // Wii U
+    describe("testing a Wii U item", function() {
+        // New Super Mario Bros. U
+        var uri = "https://www.nintendo.com/games/detail/hf_6AALqLd22OOdNFfAmJVGEfQ7pTpke";
+
+        it("should respond with a price for findItemPrice()", function(done) {
+            priceFinder.findItemPrice(uri, function(err, price) {
+                expect(err).toBeNull();
+                verifyPrice(price);
+                done();
+            });
+        });
+
+        it("should respond with a price, and the right category and name for findItemDetails()", function(done) {
+            priceFinder.findItemDetails(uri, function(err, itemDetails) {
+                expect(err).toBeNull();
+                expect(itemDetails).toBeDefined();
+
+                verifyPrice(itemDetails.price);
+                verifyName(itemDetails.name, "New Super Mario Bros. U");
+                verifyCategory(itemDetails.category, "Video Games");
+
+                done();
+            });
+        });
+    });
+
+    // 3DS
+    describe("testing a 3DS item", function() {
+        // Super Smash Bros.
+        var uri = "https://www.nintendo.com/games/detail/zC34HnrON-_wV0ZUkSfQFC6ub3Ea8DQ6";
+
+        it("should respond with a price for findItemPrice()", function(done) {
+            priceFinder.findItemPrice(uri, function(err, price) {
+                expect(err).toBeNull();
+                verifyPrice(price);
+                done();
+            });
+        });
+
+        it("should respond with a price, and the right category and name for findItemDetails()", function(done) {
+            priceFinder.findItemDetails(uri, function(err, itemDetails) {
+                expect(err).toBeNull();
+                expect(itemDetails).toBeDefined();
+
+                verifyPrice(itemDetails.price);
+                verifyName(itemDetails.name, "Super Smash Bros.");
+                verifyCategory(itemDetails.category, "Video Games");
+
+                done();
+            });
+        });
+    });
+});

--- a/test/unit/sites/nintendo-test.js
+++ b/test/unit/sites/nintendo-test.js
@@ -1,0 +1,94 @@
+"use strict";
+
+var NintendoSite = require("../../../lib/sites/nintendo"),
+    cheerio = require("cheerio"),
+    siteUtils = require("../../../lib/site-utils");
+
+var VALID_URI = "http://www.nintendo.com/product";
+var INVALID_URI = "http://www.bad.com/123/product";
+
+describe("The Nintendo Site", function() {
+
+    it("should exist", function() {
+        expect(NintendoSite).toBeDefined();
+    });
+
+    describe("isSite() function", function() {
+        it("should return true for a correct site", function() {
+            expect(NintendoSite.isSite(VALID_URI)).toBeTruthy();
+        });
+
+        it("should return false for a bad site", function() {
+            expect(NintendoSite.isSite(INVALID_URI)).toBeFalsy();
+        });
+    });
+
+    it("should throw an exception trying to create a new NintendoSite with an incorrect uri", function() {
+        expect(function() {
+            new NintendoSite(INVALID_URI);
+        }).toThrow();
+    });
+
+    describe("a new Nintento Site", function() {
+        var nintendo;
+
+        beforeEach(function() {
+            nintendo = new NintendoSite(VALID_URI);
+        });
+
+        it("should exist", function() {
+            expect(nintendo).toBeDefined();
+        });
+
+        it("should return false for isJSON()", function() {
+            expect(nintendo.isJSON()).toBeFalsy();
+        });
+
+        it("should return the same URI for getURIForPageData()", function() {
+            expect(nintendo.getURIForPageData()).toEqual(VALID_URI);
+        });
+
+        describe("with a populated page", function() {
+            var $, bad$, price, category, name;
+
+            beforeEach(function() {
+                price = 59.99;
+                category = siteUtils.categories.VIDEO_GAMES;
+                name = "New Super Mario Bros. U";
+
+                $ = cheerio.load(
+                    "<div itemprop='price'>" +
+                    "$" + price + "<sup>*</sup>" +
+                    "</div>" +
+                    "<h1 itemprop='name'>" + name + "</h1>"
+                );
+                bad$ = cheerio.load("<h1>Nothin here</h1>");
+            });
+
+            it("should return the price when displayed on the page", function() {
+                var priceFound = nintendo.findPriceOnPage($);
+                expect(priceFound).toEqual(price);
+            });
+
+            it("should return -1 when the price is not found", function() {
+                var priceFound = nintendo.findPriceOnPage(bad$);
+                expect(priceFound).toEqual(-1);
+            });
+
+            it("should return the category", function() {
+                var categoryFound = nintendo.findCategoryOnPage($);
+                expect(categoryFound).toEqual(category);
+            });
+
+            it("should return the name when displayed on the page", function() {
+                var nameFound = nintendo.findNameOnPage($, category);
+                expect(nameFound).toEqual(name);
+            });
+
+            it("should return null when the name is not displayed on the page", function() {
+                var nameFound = nintendo.findNameOnPage(bad$, category);
+                expect(nameFound).toEqual(null);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add a site for nintendo.com, pulling the price and name from the page, and hard coding the category to video games.  Add unit and end to end tests.

This should close issue #15.