### PR TITLE
Add Yen support

### DIFF
--- a/lib/site-utils.js
+++ b/lib/site-utils.js
@@ -51,6 +51,8 @@ exports.findContentOnPage = function($, selectors) {
 var DOLLAR_PREFIX = "$";
 var EURO_TEXT_PREFIX = "eur";
 var EURO_SYMBOL_PREFIX = "€";
+var YEN_TEXT_PREFIX = "円";
+var YEN_SYMBOL_PREFIX = "￥";
 
 exports.processPrice = function(priceString) {
     var price;
@@ -67,6 +69,10 @@ exports.processPrice = function(priceString) {
         _.includes(priceString, EURO_SYMBOL_PREFIX)) {
         logger.log("found euro in price, converting to number...");
         price = accounting.unformat(priceString, ",");
+    } else if (_.includes(priceString, YEN_TEXT_PREFIX) ||
+        _.includes(priceString, YEN_SYMBOL_PREFIX)) {
+        logger.log("found yen in price, converting to number...");
+        price = accounting.unformat(priceString);
     } else {
         // unknown price type!!
         logger.error("unknown price type, unable to process, returning -1");

--- a/test/unit/site-utils-test.js
+++ b/test/unit/site-utils-test.js
@@ -79,6 +79,14 @@ describe("The Site Utils", function() {
             expect(siteUtils.processPrice("€ 79,40")).toEqual(79.40);
         });
 
+        it("should process YEN_TEXT price correctly", function() {
+            expect(siteUtils.processPrice("7,940 円")).toEqual(7940);
+        });
+
+        it("should process YEN_SYMBOL price correctly", function() {
+            expect(siteUtils.processPrice("￥ 7,940")).toEqual(7940);
+        });
+
         it("should process an unknown price correctly", function() {
             expect(siteUtils.processPrice("hey, how are you?")).toEqual(-1);
         });


### PR DESCRIPTION
Add support for Japanese Yen, via the work done by @devil-tamachan.  This is a modification of the original pull request (#31), but with only the first two commits (and not the work that included support for the additional site, Surugaya).