### PR TITLE
Add selector to help find luggage items

### DIFF
--- a/lib/sites/amazon.js
+++ b/lib/sites/amazon.js
@@ -28,12 +28,12 @@ function AmazonSite(uri) {
             "#actualPriceValue",
             "#priceblock_ourprice",
             "#priceBlock .priceLarge",
-            // Yes this is weird, but for some reason "rentPrice"
-            // is the buy price
+            // Yes this is weird, but for some reason "rentPrice" is the buy price
             ".buyNewOffers .rentPrice",
             "#buybox .a-color-price",
             "#buybox_feature_div .a-button-primary .a-text-bold",
-            "#addToCart .header-price"
+            "#addToCart .header-price",
+            "#priceblock_saleprice"
         ];
 
         // find the price on the page

--- a/test/e2e/amazon-uris-test.js
+++ b/test/e2e/amazon-uris-test.js
@@ -136,4 +136,24 @@ describe("price-finder for Amazon URIs", function() {
         });
     });
 
+    // Luggage
+    describe("testing a Luggage item", function() {
+        // eBags
+        var uri = "http://www.amazon.com/eBags-Mother-Wheeled-Duffel-Yonder/dp/B001N85VMK";
+
+        it("should respond with a price, and the right category and name for findItemDetails()", function(done) {
+            priceFinder.findItemDetails(uri, function(err, itemDetails) {
+                expect(err).toBeNull();
+                expect(itemDetails).toBeDefined();
+
+                verifyPrice(itemDetails.price);
+                verifyName(itemDetails.name, "eBags TLS Mother Lode Mini 21\" Wheeled Duffel");
+                // Amazon reports "apparel" for luggage, so we default to "other"
+                verifyCategory(itemDetails.category, "Other");
+
+                done();
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
Things within the “luggage” category for Amazon seem to at times use a default sale price selector.  So add that in the hopes in covers those cases.  Also add a test to know if things break in the future.

This closes #33.