### PR TITLE
Add node v5 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "4"
+  - "5"
 sudo: false


### PR DESCRIPTION
Since we state that price-finder supports Node v4 and above, add Node v5 to the `.travis.yml` file.