### PR TITLE
Use processPrice where possible

### DIFF
--- a/lib/sites/best-buy.js
+++ b/lib/sites/best-buy.js
@@ -54,6 +54,12 @@ class BestBuySite {
         return -1;
       }
 
+      /*
+       * The salePrice is a USD number (without the dollar sign). This also
+       * means there is no need to strip the dollar sign from the price, or
+       * process it further in any way. So there is no reason to call
+       * siteUtils.processPrice on this salePrice, but instead just return it.
+       */
       return pageData.salePrice;
     }
 

--- a/lib/sites/priceminister.js
+++ b/lib/sites/priceminister.js
@@ -60,6 +60,8 @@ class PriceMinisterSite {
     // get the number value (remove euro sign)
     price = parseFloat(price.replace(',', '.'));
     shipping = parseFloat(shipping.replace(',', '.'));
+    // At this point we've already processed both the price and shipping, no
+    // need to use siteUtils.processPrice
 
     if (!isNaN(shipping)) {
       price += shipping;

--- a/lib/sites/sony-entertainment-network-store.js
+++ b/lib/sites/sony-entertainment-network-store.js
@@ -26,7 +26,7 @@ class SonyEntertainmentNetworkStoreSite {
   }
 
   findPriceOnPage(pageData) {
-    let price;
+    let priceString;
 
     // verify the default_sku exists (valid page data)
     if (!pageData || !pageData.default_sku) {
@@ -36,25 +36,23 @@ class SonyEntertainmentNetworkStoreSite {
 
     // try to get the PS Plus price first
     if (pageData.default_sku.rewards && pageData.default_sku.rewards.length > 0) {
-      price = pageData.default_sku.rewards[0].display_price;
+      priceString = pageData.default_sku.rewards[0].display_price;
 
       // account for free
-      if (price === 'Free') {
-        price = '$0';
+      if (priceString === 'Free') {
+        priceString = '$0';
       }
     } else {
       // find the default price
-      price = pageData.default_sku.display_price;
+      priceString = pageData.default_sku.display_price;
     }
 
-    if (!price) {
+    if (!priceString) {
       logger.error('price was not found on sony store page, uri: %s', this._uri);
       return -1;
     }
 
-    // get the number value (remove dollar sign)
-    price = +(price.slice(1));
-    logger.log('price: %s', price);
+    const price = siteUtils.processPrice(priceString);
 
     return price;
   }


### PR DESCRIPTION
Make sure all the sites use `siteUtils.processPrice` when processing the price of an item.  In cases where that’s not necessary, call it out in a comment.

This should close #29.