### PR TITLE
Add Steam

### DIFF
--- a/lib/site-utils.js
+++ b/lib/site-utils.js
@@ -38,7 +38,14 @@ exports.findContentOnPage = function findContentOnPage($, selectors) {
     const content = $(selectors[i]);
     if (!_.isEmpty(content)) {
       logger.log('found content with selector: %s', selectors[i]);
-      return content.text().trim();
+
+      // if it's an array, return the first element
+      if (content.length) {
+        logger.log('content is an array, attempting to return first entry');
+        return $(selectors[i]).first().text().trim();
+      } else {
+        return content.text().trim();
+      }
     }
   }
 

--- a/lib/sites/steam.js
+++ b/lib/sites/steam.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const siteUtils = require('../site-utils');
+const logger = require('../logger')();
+
+class SteamSite {
+  constructor(uri) {
+    if (!SteamSite.isSite(uri)) {
+      throw new Error('invalid uri for Steam: %s', uri);
+    }
+
+    this._uri = uri;
+  }
+
+  getURIForPageData() {
+    return this._uri;
+  }
+
+  isJSON() {
+    return false;
+  }
+
+  findPriceOnPage($) {
+    // the various ways we can find the price
+    const selectors = [
+      '.discount_final_price',
+      '.game_purchase_price',
+    ];
+
+    // find the price on the page
+    const priceString = siteUtils.findContentOnPage($, selectors);
+
+    // were we successful?
+    if (!priceString) {
+      logger.error($('body').text().trim());
+      logger.error('price not found on Steam page, uri: %s', this._uri);
+      return -1;
+    }
+
+    // process the price string
+    const price = siteUtils.processPrice(priceString);
+
+    return price;
+  }
+
+  findCategoryOnPage() {
+    // only video games on steam
+    const category = siteUtils.categories.VIDEO_GAMES;
+
+    logger.log('category: %s', category);
+
+    return category;
+  }
+
+  findNameOnPage($) {
+    // the various ways we can find the name
+    const selectors = [
+      '.apphub_AppName',
+    ];
+
+    // use the selectors to find the name on the page
+    const name = siteUtils.findContentOnPage($, selectors);
+
+    // were we successful?
+    if (!name) {
+      logger.error('name not found on Steam page, uri: %s', this._uri);
+      return null;
+    }
+
+    logger.log('name: %s', name);
+
+    return name;
+  }
+
+  static isSite(uri) {
+    if (uri.indexOf('store.steampowered.com') > -1) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+module.exports = SteamSite;

--- a/test/e2e/steam-uris-test.js
+++ b/test/e2e/steam-uris-test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// set the timeout of these tests to 10 seconds
+jasmine.getEnv().defaultTimeoutInterval = 10000;
+
+const PriceFinder = require('../../lib/price-finder');
+const priceFinder = new PriceFinder();
+
+function verifyPrice(price) {
+  expect(price).toBeDefined();
+  // we can't guarantee the price, so just make sure it's a number
+  // that's more than -1
+  expect(price).toBeGreaterThan(-1);
+}
+
+function verifyName(actualName, expectedName) {
+  expect(actualName).toEqual(expectedName);
+}
+
+function verifyCategory(actualCategory, expectedCategory) {
+  expect(actualCategory).toEqual(expectedCategory);
+}
+
+describe('price-finder for Steam Store URIs', () => {
+  describe('testing a Video Game item', () => {
+    // Don't Starve
+    const uri = 'http://store.steampowered.com/app/219740/';
+
+    it('should respond with a price for findItemPrice()', (done) => {
+      priceFinder.findItemPrice(uri, (err, price) => {
+        expect(err).toBeNull();
+        verifyPrice(price);
+        done();
+      });
+    });
+
+    it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
+      priceFinder.findItemDetails(uri, (err, itemDetails) => {
+        expect(err).toBeNull();
+        expect(itemDetails).toBeDefined();
+
+        verifyPrice(itemDetails.price);
+        verifyName(itemDetails.name, 'Don\'t Starve');
+        verifyCategory(itemDetails.category, 'Video Games');
+
+        done();
+      });
+    });
+  });
+});

--- a/test/unit/site-utils-test.js
+++ b/test/unit/site-utils-test.js
@@ -27,7 +27,12 @@ describe('The Site Utils', () => {
     let $;
 
     beforeEach(() => {
-      $ = cheerio.load('<div id="price-tag">$9.99</div>');
+      $ = cheerio.load(
+        `<div id='price-tag'>$9.99</div>
+         <div class='multi-price'>$1.99</div>
+         <div class='multi-price'>$2.99</div>
+         <div class='multi-price'>$3.99</div>`
+      );
     });
 
     it('should return the price given the correct selector', () => {
@@ -38,6 +43,16 @@ describe('The Site Utils', () => {
       const price = siteUtils.findContentOnPage($, selectors);
 
       expect(price).toEqual('$9.99');
+    });
+
+    it('should return the price given the multiple matches for selector', () => {
+      const selectors = [
+        '.multi-price',
+      ];
+
+      const price = siteUtils.findContentOnPage($, selectors);
+
+      expect(price).toEqual('$1.99');
     });
 
     it('should return null given incorrect selector', () => {

--- a/test/unit/sites/steam-test.js
+++ b/test/unit/sites/steam-test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const SteamSite = require('../../../lib/sites/steam');
+const cheerio = require('cheerio');
+const siteUtils = require('../../../lib/site-utils');
+
+const VALID_URI = 'http://store.steampowered.com/123/product';
+const INVALID_URI = 'http://www.bad.com/123/product';
+
+describe('The Steam Site', () => {
+  it('should exist', () => {
+    expect(SteamSite).toBeDefined();
+  });
+
+  describe('isSite() function', () => {
+    it('should return true for a correct site', () => {
+      expect(SteamSite.isSite(VALID_URI)).toBeTruthy();
+    });
+
+    it('should return false for a bad site', () => {
+      expect(SteamSite.isSite(INVALID_URI)).toBeFalsy();
+    });
+  });
+
+  it('should throw an exception trying to create a new site with an incorrect uri', () => {
+    expect(() => {
+      /* eslint-disable no-new */
+      new SteamSite(INVALID_URI);
+      /* eslint-enable no-new */
+    }).toThrow();
+  });
+
+  describe('a new Steam Site', () => {
+    let site;
+
+    beforeEach(() => {
+      site = new SteamSite(VALID_URI);
+    });
+
+    it('should exist', () => {
+      expect(site).toBeDefined();
+    });
+
+    it('should return the same URI for getURIForPageData()', () => {
+      expect(site.getURIForPageData()).toEqual(VALID_URI);
+    });
+
+    it('should return false for isJSON()', () => {
+      expect(site.isJSON()).toBeFalsy();
+    });
+
+    describe('with a populated page', () => {
+      let $;
+      let bad$;
+      let price;
+      let category;
+      let name;
+
+      beforeEach(() => {
+        price = 1.99;
+        category = siteUtils.categories.VIDEO_GAMES;
+        name = 'Cool Game';
+
+        $ = cheerio.load(`<div class='game_purchase_price'>
+          $${price}
+          </div>
+          <div class='apphub_AppName'>
+          ${name}
+          </div>'`);
+        bad$ = cheerio.load('<h1>Nothin here</h1>');
+      });
+
+      it('should return the price when displayed on the page', () => {
+        const priceFound = site.findPriceOnPage($);
+        expect(priceFound).toEqual(price);
+      });
+
+      it('should return the price when discounted on the page', () => {
+        $ = cheerio.load(`<div class='discount_final_price'>$${price}</div>`);
+        const priceFound = site.findPriceOnPage($);
+        expect(priceFound).toEqual(price);
+      });
+
+      it('should return -1 when the price is not found', () => {
+        const priceFound = site.findPriceOnPage(bad$);
+        expect(priceFound).toEqual(-1);
+      });
+
+      it('should always return the category', () => {
+        const categoryFound = site.findCategoryOnPage($);
+        expect(categoryFound).toEqual(category);
+      });
+
+      it('should return the name when displayed on the page', () => {
+        const nameFound = site.findNameOnPage($, category);
+        expect(nameFound).toEqual(name);
+      });
+
+      it('should return null when the name is not displayed on the page', () => {
+        const nameFound = site.findNameOnPage(bad$, category);
+        expect(nameFound).toEqual(null);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add support for Steam’s website.  We look for the discounted price prior to looking for the game purchase price in case there’s a sale going on.

By the way, this was the first site that I used the Yeoman generator to create:
https://github.com/dylants/generator-price-finder-site

This PR includes a change to `siteUtils.findContentOnPage` to return the first element when multiple are found for a selector.  This was necessary to avoid getting a list of prices instead of a single one.

This should close #38 