### PR TITLE
Support find(), improve Steam query

### DIFF
--- a/lib/site-utils.js
+++ b/lib/site-utils.js
@@ -33,16 +33,19 @@ exports.categories = Object.freeze({
 exports.findContentOnPage = function findContentOnPage($, selectors) {
   logger.log('selectors: %j', selectors);
 
+  // use the find() API in case we're handed an inner jquery object
+  const jQuery = _.isFunction($.find) ? $.find.bind($) : $;
+
   // loop until we find the content, or we exhaust our selectors
   for (let i = 0; i < selectors.length; i++) {
-    const content = $(selectors[i]);
+    const content = jQuery(selectors[i]);
     if (!_.isEmpty(content)) {
       logger.log('found content with selector: %s', selectors[i]);
 
       // if it's an array, return the first element
       if (content.length) {
         logger.log('content is an array, attempting to return first entry');
-        return $(selectors[i]).first().text().trim();
+        return jQuery(selectors[i]).first().text().trim();
       } else {
         return content.text().trim();
       }

--- a/lib/sites/steam.js
+++ b/lib/sites/steam.js
@@ -21,6 +21,9 @@ class SteamSite {
   }
 
   findPriceOnPage($) {
+    // we need to limit the scope of the query to the first panel
+    const jQuery = $('.game_area_purchase_game').first();
+
     // the various ways we can find the price
     const selectors = [
       '.discount_final_price',
@@ -28,11 +31,10 @@ class SteamSite {
     ];
 
     // find the price on the page
-    const priceString = siteUtils.findContentOnPage($, selectors);
+    const priceString = siteUtils.findContentOnPage(jQuery, selectors);
 
     // were we successful?
     if (!priceString) {
-      logger.error($('body').text().trim());
       logger.error('price not found on Steam page, uri: %s', this._uri);
       return -1;
     }
@@ -56,6 +58,7 @@ class SteamSite {
     // the various ways we can find the name
     const selectors = [
       '.apphub_AppName',
+      '.page_title_area .pageheader',
     ];
 
     // use the selectors to find the name on the page

--- a/test/unit/site-utils-test.js
+++ b/test/unit/site-utils-test.js
@@ -27,12 +27,18 @@ describe('The Site Utils', () => {
     let $;
 
     beforeEach(() => {
-      $ = cheerio.load(
-        `<div id='price-tag'>$9.99</div>
-         <div class='multi-price'>$1.99</div>
-         <div class='multi-price'>$2.99</div>
-         <div class='multi-price'>$3.99</div>`
-      );
+      $ = cheerio.load(`
+        <div id='price-tag'>$9.99</div>
+        <div class='multi-price'>$1.99</div>
+        <div class='multi-price'>$2.99</div>
+        <div class='multi-price'>$3.99</div>
+        <div class='outer-multi'>
+          <div class='inner'>$12.34</div>
+        </div>
+        <div class='outer-multi'>
+          <div class='inner'>$56.78</div>
+        </div>
+      `);
     });
 
     it('should return the price given the correct selector', () => {
@@ -53,6 +59,18 @@ describe('The Site Utils', () => {
       const price = siteUtils.findContentOnPage($, selectors);
 
       expect(price).toEqual('$1.99');
+    });
+
+    it('should return the price given a first() element', () => {
+      const jQuery = $('.outer-multi').first();
+
+      const selectors = [
+        '.inner',
+      ];
+
+      const price = siteUtils.findContentOnPage(jQuery, selectors);
+
+      expect(price).toEqual('$12.34');
     });
 
     it('should return null given incorrect selector', () => {

--- a/test/unit/sites/steam-test.js
+++ b/test/unit/sites/steam-test.js
@@ -61,12 +61,21 @@ describe('The Steam Site', () => {
         category = siteUtils.categories.VIDEO_GAMES;
         name = 'Cool Game';
 
-        $ = cheerio.load(`<div class='game_purchase_price'>
-          $${price}
-          </div>
-          <div class='apphub_AppName'>
-          ${name}
-          </div>'`);
+        $ = cheerio.load(`
+          <div class='game_area_purchase_game'>
+            <div class='game_purchase_price'>
+              $${price}
+            </div>
+            <div class='apphub_AppName'>
+              ${name}
+            </div>
+          </div>'
+          <div class='game_area_purchase_game'>
+            <div class='game_purchase_price'>
+              $999.99
+            </div>
+          </div>'
+        `);
         bad$ = cheerio.load('<h1>Nothin here</h1>');
       });
 
@@ -76,7 +85,11 @@ describe('The Steam Site', () => {
       });
 
       it('should return the price when discounted on the page', () => {
-        $ = cheerio.load(`<div class='discount_final_price'>$${price}</div>`);
+        $ = cheerio.load(`
+          <div class='game_area_purchase_game'>
+            <div class='discount_final_price'>$${price}</div>
+          </div>
+        `);
         const priceFound = site.findPriceOnPage($);
         expect(priceFound).toEqual(price);
       });


### PR DESCRIPTION
The Steam query requires that we limit the scope of the inner queries (for the price) by an outer scope (the first game panel display).  To do this, we’ll first query the outer scope, find the first element, and then pass that to the `siteUtils.findContentOnPage` to perform the inner queries for price.

With this new requirement, we may be passing the original jQuery object or the inner first() one described above to the `findContentOnPage` function.  So update the function to check if the `find()` function is available on the jQuery object, and if so, use that.  Otherwise we proceed as we normally would.