### PR TITLE
Fix Newegg end to end test: findPriceOnPage

### DIFF
--- a/lib/sites/newegg.js
+++ b/lib/sites/newegg.js
@@ -22,20 +22,28 @@ class NewEggSite {
   }
 
   findPriceOnPage($) {
-    // the various ways we can find the price on an newegg page
-    const selectors = [
-      '#singleFinalPrice',
-    ];
-
-    // find the price on the page
-    const priceString = siteUtils.findContentOnPage($, selectors);
+    /*
+     * It looks like newegg is a bit unique, in that they don't (at this time)
+     * return a page that contains the price within the HTML. Perhaps they inject
+     * it later, but we're not sure. Because of this unfortunate situation, we
+     * must read the price from some javascript loaded on the page. We do this
+     * in a most yucky way: regex!
+     */
+    const regex = /product_sale_price:\['(.*)'\]/ig;
+    const results = regex.exec($.html());
+    let priceString;
+    if (results && results.length > 1) {
+      priceString = results[1];
+    }
 
     // were we successful?
     if (!priceString) {
-      logger.error($('body').text().trim());
       logger.error('price not found on newgg page, uri: %s', this._uri);
       return -1;
     }
+
+    // if we were successful, the code above assumes USD
+    priceString = `$ ${priceString}`;
 
     // process the price string
     const price = siteUtils.processPrice(priceString);

--- a/test/e2e/newegg-uris-test.js
+++ b/test/e2e/newegg-uris-test.js
@@ -8,6 +8,7 @@ const priceFinder = new PriceFinder();
 
 function verifyPrice(price) {
   expect(price).toBeDefined();
+
   // we can't guarantee the price, so just make sure it's a number
   // that's more than -1
   expect(price).toBeGreaterThan(-1);
@@ -28,10 +29,8 @@ function verifyCategory(actualCategory, expectedCategory) {
  * are thrown and the tests fail (and our IP is blacklisted).
  */
 describe('price-finder for NewEgg URIs', () => {
-  // Digital Music
   describe('testing a Mobile Phone item', () => {
-    // Atoms for Peace : Amok
-    const uri = 'http://www.newegg.com/Product/Product.aspx?Item=N82E16875705040&cm_sp=Homepage_FDD-_-P1_75-705-040-_-02162016';
+    const uri = 'http://www.newegg.com/Product/Product.aspx?Item=N82E16875705040';
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {

--- a/test/unit/sites/newegg-test.js
+++ b/test/unit/sites/newegg-test.js
@@ -4,7 +4,7 @@ const NewEggSite = require('../../../lib/sites/newegg');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
 
-const VALID_URI = 'http://www.newegg.com/Product/Product.aspx?Item=N82E16875705040&cm_sp=Homepage_FDD-_-P1_75-705-040-_-02162016';
+const VALID_URI = 'http://www.newegg.com/Product/Product.aspx?Item=N82E16875705040';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The NewEgg Site', () => {
@@ -61,14 +61,16 @@ describe('The NewEgg Site', () => {
         category = siteUtils.categories.MOBILE;
         name = 'Axon by ZTE Unlocked GSM, 5.5", Qualcomm Snapdragon 801 2.4 GHz Quad-Core';
 
-        $ = cheerio.load(`<li class="price-current" itemprop="price" content="329.98"
-          id="singleFinalPrice"><meta itemprop="priceCurrency" content="USD">
-          <span class="price-current-label"></span>$<strong>329</strong>
-          <sup>.98</sup><span class="price-current-range">
-          <abbr title="to">–</abbr></span></li><h1 id="grpDescrip_h">
-          <span id="grpDescrip_75-705-040" itemprop="name" style="display: inline;">
-          Axon by ZTE Unlocked GSM, 5.5", Qualcomm Snapdragon 801 2.4 GHz Quad-Core</span></h1>
-          <div id="baBreadcrumbTop" data-category="something-new">stuff</div>`);
+        $ = cheerio.load(`
+          <html>
+            <div id='grpDescrip_h'>${name}</div>
+            <script type='text/javascript'>
+              var utag_data = {
+                foo:'bar',
+                product_sale_price:['329.98'],
+              };
+            </script>
+          </html>`);
         bad$ = cheerio.load('<h1>Nothin here</h1>');
       });
 
@@ -90,13 +92,13 @@ describe('The NewEgg Site', () => {
           Home</a>&nbsp;&gt;&nbsp;</dd><dd><a href="http://www.newegg.com/Electronics/Store"
           title="Electronics">Electronics</a>&nbsp;&gt;&nbsp;</dd><dd>
           <a href="http://www.newegg.com/Cell-Phones-Unlocked/Category/ID-249?Tid=161538"
-           title="Cell Phones - Unlocked">Cell Phones - Unlocked</a>&nbsp;&gt;&nbsp;</dd>
-           <dd><a href="http://www.newegg.com/Cell-Phones-Unlocked/SubCategory/ID-2961?Tid=161551"
-            title="Cell Phones - Unlocked">Cell Phones - Unlocked</a>&nbsp;&gt;&nbsp;</dd>
-            <dd><a href="http://www.newegg.com/ZTE-Cell-Phones-Unlocked/BrandSubCat/ID-14576-2961"
-             title="ZTE">ZTE</a>&nbsp;&gt;&nbsp;</dd>
-             <dd style="font-weight:bold;font-style:italic;">Item#:&nbsp;<em>N82E16875705040</em>
-             </dd></dl></div>`);
+          title="Cell Phones - Unlocked">Cell Phones - Unlocked</a>&nbsp;&gt;&nbsp;</dd>
+          <dd><a href="http://www.newegg.com/Cell-Phones-Unlocked/SubCategory/ID-2961?Tid=161551"
+          title="Cell Phones - Unlocked">Cell Phones - Unlocked</a>&nbsp;&gt;&nbsp;</dd>
+          <dd><a href="http://www.newegg.com/ZTE-Cell-Phones-Unlocked/BrandSubCat/ID-14576-2961"
+          title="ZTE">ZTE</a>&nbsp;&gt;&nbsp;</dd>
+          <dd style="font-weight:bold;font-style:italic;">Item#:&nbsp;<em>N82E16875705040</em>
+          </dd></dl></div>`);
         const categoryFound = newegg.findCategoryOnPage($);
         expect(categoryFound).toEqual(category);
       });
@@ -109,13 +111,13 @@ describe('The NewEgg Site', () => {
           Home</a>&nbsp;&gt;&nbsp;</dd><dd><a href="http://www.newegg.com/Electronics/Store"
           title="Electronics">Electronics</a>&nbsp;&gt;&nbsp;</dd><dd>
           <a href="http://www.newegg.com/Cell-Phones-Unlocked/Category/ID-249?Tid=161538"
-           title="Cell Phones - Unlocked"></a>&nbsp;&gt;&nbsp;</dd>
-           <dd><a href="http://www.newegg.com/Cell-Phones-Unlocked/SubCategory/ID-2961?Tid=161551"
-            title="Cell Phones - Unlocked"></a>&nbsp;&gt;&nbsp;</dd>
-            <dd><a href="http://www.newegg.com/ZTE-Cell-Phones-Unlocked/BrandSubCat/ID-14576-2961"
-             title="ZTE">ZTE</a>&nbsp;&gt;&nbsp;</dd>
-             <dd style="font-weight:bold;font-style:italic;">Item#:&nbsp;<em>N82E16875705040</em>
-             </dd></dl></div>`);
+          title="Cell Phones - Unlocked"></a>&nbsp;&gt;&nbsp;</dd>
+          <dd><a href="http://www.newegg.com/Cell-Phones-Unlocked/SubCategory/ID-2961?Tid=161551"
+          title="Cell Phones - Unlocked"></a>&nbsp;&gt;&nbsp;</dd>
+          <dd><a href="http://www.newegg.com/ZTE-Cell-Phones-Unlocked/BrandSubCat/ID-14576-2961"
+          title="ZTE">ZTE</a>&nbsp;&gt;&nbsp;</dd>
+          <dd style="font-weight:bold;font-style:italic;">Item#:&nbsp;<em>N82E16875705040</em>
+          </dd></dl></div>`);
         const categoryFound = newegg.findCategoryOnPage($);
         expect(categoryFound).toEqual(siteUtils.categories.OTHER);
       });


### PR DESCRIPTION
This problem was first found because the end to end tests for Newegg failed, in that they couldn’t find the price on the site.  After some investigation, it appeared that the price was not on the initial HTML page returned from the request call, but perhaps later added to the page?  What’s weird is that this might have worked in the past?  Unsure…

Either way the current method wasn’t working.  Looking at the HTML returned from the request, it looks like the price _is_ available in some javascript near the bottom of the page.  We can get access to this price via a regular expression.

Update the tests to align with these changes.

This should close #49.