### PR TITLE
Correct callback error string

### DIFF
--- a/lib/price-finder.js
+++ b/lib/price-finder.js
@@ -2,6 +2,7 @@
 
 const async = require('async');
 /* eslint-disable prefer-const */
+
 // TODO no const for testing https://github.com/jhnns/rewire/issues/79
 let request = require('request');
 /* eslint-enable prefer-const */
@@ -68,7 +69,7 @@ class PriceFinder {
       // error check
       if (price === -1) {
         logger.error('unable to find price');
-        return callback('unable to find price for uri: %s', uri);
+        return callback(`unable to find price for uri: ${uri}`);
       }
 
       logger.log('price found, returning price: %s', price);
@@ -122,7 +123,7 @@ class PriceFinder {
       // error check
       if (itemDetails.price === -1) {
         logger.error('unable to find price');
-        return callback('unable to find price for uri: %s', uri);
+        return callback(`unable to find price for uri: ${uri}`);
       }
 
       logger.log('price found, loading category from site...');
@@ -152,6 +153,7 @@ class PriceFinder {
     let pageData;
 
     async.whilst(
+
       // run until we get page data
       () => !pageData,
 


### PR DESCRIPTION
This was a copy/paste bug in assuming it was going to be handled by the logger and the second argument would populate the string template.  Fix this to use a template string.

This should close #48.