### PR TITLE
E2E tests: refactor and add to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
+env:
+  global:
+    # This is the encrypted best buy environment variable necessary for e2e tests
+    # https://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables
+    - secure: rKDobPRIciKKXwpbPG8pt1wP7T5iSmyDrfigJPJ1nLj4R/hZUGokV3T8X3ugdmUzOChKpFQzH7wIPQYaXPKehmNDJpuaBLJExfjV35wUdQpsOBWjkdms92+2R+mN/mhi9U98w06kNwXRcMv/XhsZwnU+ev9sKBb4Cqx1Gh1Oi8Y=
+  matrix:
+    # We want to run both (unit) tests and end to end tests as a matrix
+    # https://docs.travis-ci.com/user/speeding-up-the-build/#Parallelizing-your-builds-across-virtual-machines
+    - TEST_SUITE=test
+    - TEST_SUITE=test-e2e
 language: node_js
 node_js:
   - "4"
   - "5"
+script: "npm run $TEST_SUITE"
 sudo: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,11 @@ module.exports = function exports(grunt) {
         quiet: true,
       },
     },
+    env: {
+      e2e: {
+        DEBUG: 'price-finder*',
+      },
+    },
     jasmine_nodejs: {
       options: {
         specNameSuffix: 'test.js',
@@ -23,8 +28,11 @@ module.exports = function exports(grunt) {
           },
         },
       },
-      all: {
+      unit: {
         specs: ['test/unit/**'],
+      },
+      e2e: {
+        specs: ['test/e2e/**'],
       },
     },
   });
@@ -32,5 +40,6 @@ module.exports = function exports(grunt) {
   // load all the grunt tasks at once
   require('load-grunt-tasks')(grunt);
 
-  grunt.registerTask('test', ['eslint', 'jasmine_nodejs']);
+  grunt.registerTask('test', ['eslint', 'jasmine_nodejs:unit']);
+  grunt.registerTask('e2e', ['env:e2e', 'jasmine_nodejs:e2e']);
 };

--- a/lib/price-finder.js
+++ b/lib/price-finder.js
@@ -191,7 +191,7 @@ class PriceFinder {
               return setTimeout(() => whilstCallback(), this._config.retrySleepTime);
             } else {
               // else it's a bad response status, all stop
-              return whilstCallback('response status: %s', response.statusCode);
+              return whilstCallback(`response status: ${response.statusCode}`);
             }
           } else {
             return whilstCallback('no response object found!');

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   "scripts": {
     "prepublish": "npm prune",
     "test": "grunt test",
+    "test-e2e": "grunt e2e",
     "test-watch": "jasmine-node --test-dir test/unit --matchall --color --autotest --watch lib",
-    "test-e2e": "DEBUG=price-finder* jasmine-node --test-dir test/e2e --matchall --color --verbose --noStack",
     "test-e2e-single": "DEBUG=price-finder* jasmine-node --matchall --color --verbose --noStack $1"
   },
   "dependencies": {
@@ -56,12 +56,13 @@
   "devDependencies": {
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.0",
-    "jasmine-node": "^1.14.3",
-    "rewire": "^2.0.0",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-env": "^0.4.4",
     "grunt-eslint": "^17.3.1",
     "grunt-jasmine-nodejs": "^1.4.3",
-    "grunt-cli": "^0.1.13",
-    "grunt": "^0.4.5",
-    "load-grunt-tasks": "^3.2.0"
+    "jasmine-node": "^1.14.3",
+    "load-grunt-tasks": "^3.2.0",
+    "rewire": "^2.0.0"
   }
 }

--- a/test/e2e/amazon-uris-test.js
+++ b/test/e2e/amazon-uris-test.js
@@ -1,25 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 /*
  * I've seen some CAPTCHA's from Amazon if you hit them too much too often,
@@ -30,8 +15,8 @@ function verifyCategory(actualCategory, expectedCategory) {
 describe('price-finder for Amazon URIs', () => {
   // Digital Music
   describe('testing a Digital Music item', () => {
-    // Atoms for Peace : Amok
-    const uri = 'http://www.amazon.com/Amok/dp/B00BIQ1EL4';
+    // Coldplay: A Rush Of Blood To The Head
+    const uri = 'https://www.amazon.com/gp/product/B00KHEHEGM';
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
@@ -44,12 +29,7 @@ describe('price-finder for Amazon URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Atoms For Peace: Amok');
-        verifyCategory(itemDetails.category, 'Digital Music');
-
+        verifyItemDetails(itemDetails, 'Coldplay: A Rush Of Blood To The Head', 'Digital Music');
         done();
       });
     });
@@ -67,12 +47,7 @@ describe('price-finder for Amazon URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Pikmin 3');
-        verifyCategory(itemDetails.category, 'Video Games');
-
+        verifyItemDetails(itemDetails, 'Pikmin 3', 'Video Games');
         done();
       });
     });
@@ -81,17 +56,12 @@ describe('price-finder for Amazon URIs', () => {
   // Mobile Apps
   describe('testing a Mobile Apps item', () => {
     // Minecraft
-    const uri = 'http://www.amazon.com/Mojang-Minecraft-Pocket-Edition/dp/B00992CF6W';
+    const uri = 'http://www.amazon.com/gp/product/B00992CF6W';
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Minecraft - Pocket Edition');
-        verifyCategory(itemDetails.category, 'Mobile Apps');
-
+        verifyItemDetails(itemDetails, 'Minecraft - Pocket Edition', 'Mobile Apps');
         done();
       });
     });
@@ -105,12 +75,7 @@ describe('price-finder for Amazon URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'The Blues Brothers [Blu-ray]');
-        verifyCategory(itemDetails.category, 'Movies & TV');
-
+        verifyItemDetails(itemDetails, 'The Blues Brothers [Blu-ray]', 'Movies & TV');
         done();
       });
     });
@@ -124,12 +89,7 @@ describe('price-finder for Amazon URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Origins: Fourteen Billion Years of Cosmic Evolution');
-        verifyCategory(itemDetails.category, 'Books');
-
+        verifyItemDetails(itemDetails, 'Origins: Fourteen Billion Years of Cosmic Evolution', 'Books');
         done();
       });
     });
@@ -143,13 +103,9 @@ describe('price-finder for Amazon URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
 
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'eBags TLS Mother Lode Mini 21" Wheeled Duffel');
         // Amazon reports 'apparel' for luggage, so we default to 'other'
-        verifyCategory(itemDetails.category, 'Other');
-
+        verifyItemDetails(itemDetails, 'eBags TLS Mother Lode Mini 21" Wheeled Duffel', 'Other');
         done();
       });
     });

--- a/test/e2e/best-buy-uris-test.js
+++ b/test/e2e/best-buy-uris-test.js
@@ -1,26 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for Best Buy URIs', () => {
   it('should have the API key defined', (done) => {
@@ -44,12 +28,7 @@ describe('price-finder for Best Buy URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Briefcase Full of Blues - CD');
-        verifyCategory(itemDetails.category, 'Music');
-
+        verifyItemDetails(itemDetails, 'Briefcase Full of Blues - CD', 'Music');
         done();
       });
     });
@@ -71,12 +50,7 @@ describe('price-finder for Best Buy URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Ferris Bueller\'s Day Off (DVD)');
-        verifyCategory(itemDetails.category, 'Movies & TV');
-
+        verifyItemDetails(itemDetails, 'Ferris Bueller\'s Day Off (DVD)', 'Movies & TV');
         done();
       });
     });
@@ -98,12 +72,7 @@ describe('price-finder for Best Buy URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Super Mario 3D Land - Nintendo 3DS');
-        verifyCategory(itemDetails.category, 'Video Games');
-
+        verifyItemDetails(itemDetails, 'Super Mario 3D Land - Nintendo 3DS', 'Video Games');
         done();
       });
     });

--- a/test/e2e/best-buy-uris-test.js
+++ b/test/e2e/best-buy-uris-test.js
@@ -6,6 +6,13 @@ const priceFinder = testHelper.priceFinder;
 const verifyPrice = testHelper.verifyPrice;
 const verifyItemDetails = testHelper.verifyItemDetails;
 
+/*
+ * To avoid spamming the API, sleep a bit between tests
+ */
+function waitForDone(done) {
+  setTimeout(() => done(), 5000);
+}
+
 describe('price-finder for Best Buy URIs', () => {
   it('should have the API key defined', (done) => {
     expect(process.env.BESTBUY_KEY).toBeDefined();
@@ -21,7 +28,7 @@ describe('price-finder for Best Buy URIs', () => {
       priceFinder.findItemPrice(uri, (err, price) => {
         expect(err).toBeNull();
         verifyPrice(price);
-        done();
+        waitForDone(done);
       });
     });
 
@@ -29,7 +36,7 @@ describe('price-finder for Best Buy URIs', () => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
         verifyItemDetails(itemDetails, 'Briefcase Full of Blues - CD', 'Music');
-        done();
+        waitForDone(done);
       });
     });
   });
@@ -43,7 +50,7 @@ describe('price-finder for Best Buy URIs', () => {
       priceFinder.findItemPrice(uri, (err, price) => {
         expect(err).toBeNull();
         verifyPrice(price);
-        done();
+        waitForDone(done);
       });
     });
 
@@ -51,7 +58,7 @@ describe('price-finder for Best Buy URIs', () => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
         verifyItemDetails(itemDetails, 'Ferris Bueller\'s Day Off (DVD)', 'Movies & TV');
-        done();
+        waitForDone(done);
       });
     });
   });
@@ -65,7 +72,7 @@ describe('price-finder for Best Buy URIs', () => {
       priceFinder.findItemPrice(uri, (err, price) => {
         expect(err).toBeNull();
         verifyPrice(price);
-        done();
+        waitForDone(done);
       });
     });
 
@@ -73,7 +80,7 @@ describe('price-finder for Best Buy URIs', () => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
         verifyItemDetails(itemDetails, 'Super Mario 3D Land - Nintendo 3DS', 'Video Games');
-        done();
+        waitForDone(done);
       });
     });
   });

--- a/test/e2e/crutchfield-uris-test.js
+++ b/test/e2e/crutchfield-uris-test.js
@@ -1,25 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for Crutchfield Store URIs', () => {
   // Television & Video
@@ -38,12 +23,7 @@ describe('price-finder for Crutchfield Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Samsung BD-J5700');
-        verifyCategory(itemDetails.category, 'Television & Video');
-
+        verifyItemDetails(itemDetails, 'Samsung BD-J5700', 'Television & Video');
         done();
       });
     });
@@ -65,12 +45,7 @@ describe('price-finder for Crutchfield Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Marantz NR1504');
-        verifyCategory(itemDetails.category, 'Home Audio');
-
+        verifyItemDetails(itemDetails, 'Marantz NR1504', 'Home Audio');
         done();
       });
     });

--- a/test/e2e/ebags-uris-test.js
+++ b/test/e2e/ebags-uris-test.js
@@ -1,25 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for eBags Store URIs', () => {
   // Luggage
@@ -38,12 +23,7 @@ describe('price-finder for eBags Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'TLS Mother Lode Mini 21" Wheeled Duffel');
-        verifyCategory(itemDetails.category, 'Luggage');
-
+        verifyItemDetails(itemDetails, 'TLS Mother Lode Mini 21" Wheeled Duffel', 'Luggage');
         done();
       });
     });

--- a/test/e2e/gamestop-uris-test.js
+++ b/test/e2e/gamestop-uris-test.js
@@ -1,25 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for GameStop Store URIs', () => {
   // Video Games
@@ -38,12 +23,7 @@ describe('price-finder for GameStop Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Mario Kart 8');
-        verifyCategory(itemDetails.category, 'Video Games');
-
+        verifyItemDetails(itemDetails, 'Mario Kart 8', 'Video Games');
         done();
       });
     });

--- a/test/e2e/google-play-uris-test.js
+++ b/test/e2e/google-play-uris-test.js
@@ -1,25 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for Google Play URIs', () => {
   // Digital Music
@@ -38,12 +23,7 @@ describe('price-finder for Google Play URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'AMOK');
-        verifyCategory(itemDetails.category, 'Digital Music');
-
+        verifyItemDetails(itemDetails, 'AMOK', 'Digital Music');
         done();
       });
     });
@@ -65,12 +45,7 @@ describe('price-finder for Google Play URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Big');
-        verifyCategory(itemDetails.category, 'Movies & TV');
-
+        verifyItemDetails(itemDetails, 'Big', 'Movies & TV');
         done();
       });
     });
@@ -92,12 +67,7 @@ describe('price-finder for Google Play URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Plants vs. Zombies™');
-        verifyCategory(itemDetails.category, 'Mobile Apps');
-
+        verifyItemDetails(itemDetails, 'Plants vs. Zombies™', 'Mobile Apps');
         done();
       });
     });

--- a/test/e2e/infibeam-uris-test.js
+++ b/test/e2e/infibeam-uris-test.js
@@ -1,26 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for Infibeam Store URIs', () => {
   describe('testing Sansui SJX22FB Full HD LED TV item', () => {
@@ -37,12 +21,7 @@ describe('price-finder for Infibeam Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Sansui SJX22FB Full HD LED TV');
-        verifyCategory(itemDetails.category, 'Electronics');
-
+        verifyItemDetails(itemDetails, 'Sansui SJX22FB Full HD LED TV', 'Electronics');
         done();
       });
     });

--- a/test/e2e/newegg-uris-test.js
+++ b/test/e2e/newegg-uris-test.js
@@ -27,9 +27,9 @@ describe('price-finder for NewEgg URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        verifyItemDetails(itemDetails, 'Axon by ZTE Unlocked GSM, 5.5", Qualcomm ' +
-          'Snapdragon 801 2.4 GHz Quad-Core, 2GB Ram, 32GB Rom, 4G/LTE, JBL E13 ' +
-          'Headphones in package - Gold', 'Mobile Phones');
+        verifyItemDetails(itemDetails, 'Axon - ZTE Unlocked Smartphone, 5.5" ' +
+          'Qualcomm Snapdragon 801, 2GB RAM, 4G LTE, Quick-charge 2.0 - 32GB Gold',
+          'Mobile Phones');
         done();
       });
     });

--- a/test/e2e/newegg-uris-test.js
+++ b/test/e2e/newegg-uris-test.js
@@ -1,26 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 /*
  * I've seen some CAPTCHA's from NewEgg if you hit them too much too often,
@@ -43,13 +27,9 @@ describe('price-finder for NewEgg URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Axon by ZTE Unlocked GSM, 5.5", Qualcomm Snapdragon 801 2.4 GHz Quad-Core, 2GB Ram, ' +
-          '32GB Rom, 4G/LTE, JBL E13 Headphones in package - Gold');
-        verifyCategory(itemDetails.category, 'Mobile Phones');
-
+        verifyItemDetails(itemDetails, 'Axon by ZTE Unlocked GSM, 5.5", Qualcomm ' +
+          'Snapdragon 801 2.4 GHz Quad-Core, 2GB Ram, 32GB Rom, 4G/LTE, JBL E13 ' +
+          'Headphones in package - Gold', 'Mobile Phones');
         done();
       });
     });

--- a/test/e2e/nintendo-uris-test.js
+++ b/test/e2e/nintendo-uris-test.js
@@ -1,25 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for Nintendo URIs', () => {
   // Wii U
@@ -38,12 +23,7 @@ describe('price-finder for Nintendo URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'New Super Mario Bros. U');
-        verifyCategory(itemDetails.category, 'Video Games');
-
+        verifyItemDetails(itemDetails, 'New Super Mario Bros. U', 'Video Games');
         done();
       });
     });
@@ -65,12 +45,7 @@ describe('price-finder for Nintendo URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Super Smash Bros.');
-        verifyCategory(itemDetails.category, 'Video Games');
-
+        verifyItemDetails(itemDetails, 'Super Smash Bros.', 'Video Games');
         done();
       });
     });

--- a/test/e2e/priceminister-uris-test.js
+++ b/test/e2e/priceminister-uris-test.js
@@ -1,25 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for PriceMinister Store URIs', () => {
   // Video Games
@@ -38,12 +23,7 @@ describe('price-finder for PriceMinister Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Gta 4 jeu video');
-        verifyCategory(itemDetails.category, 'Video Games');
-
+        verifyItemDetails(itemDetails, 'Gta 4 jeu video', 'Video Games');
         done();
       });
     });

--- a/test/e2e/sony-entertainment-network-store-uris-test.js
+++ b/test/e2e/sony-entertainment-network-store-uris-test.js
@@ -1,25 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for Sony Entertainment Network Store URIs', () => {
   // Video Games
@@ -38,12 +23,7 @@ describe('price-finder for Sony Entertainment Network Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'PixelJunk™ Monsters');
-        verifyCategory(itemDetails.category, 'Video Games');
-
+        verifyItemDetails(itemDetails, 'PixelJunk™ Monsters', 'Video Games');
         done();
       });
     });

--- a/test/e2e/steam-uris-test.js
+++ b/test/e2e/steam-uris-test.js
@@ -1,25 +1,10 @@
 'use strict';
 
-// set the timeout of these tests to 10 seconds
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const testHelper = require('./test-helper');
 
-const PriceFinder = require('../../lib/price-finder');
-const priceFinder = new PriceFinder();
-
-function verifyPrice(price) {
-  expect(price).toBeDefined();
-  // we can't guarantee the price, so just make sure it's a number
-  // that's more than -1
-  expect(price).toBeGreaterThan(-1);
-}
-
-function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
-}
-
-function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
-}
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for Steam Store URIs', () => {
   describe('testing a Video Game item', () => {
@@ -37,12 +22,7 @@ describe('price-finder for Steam Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        expect(itemDetails).toBeDefined();
-
-        verifyPrice(itemDetails.price);
-        verifyName(itemDetails.name, 'Don\'t Starve');
-        verifyCategory(itemDetails.category, 'Video Games');
-
+        verifyItemDetails(itemDetails, 'Don\'t Starve', 'Video Games');
         done();
       });
     });

--- a/test/e2e/test-helper.js
+++ b/test/e2e/test-helper.js
@@ -1,0 +1,44 @@
+'use strict';
+
+// set the timeout for each test to 60 seconds (crazy! but necessary it seems)
+const TEST_TIMEOUT = 60000;
+
+// set the price-finder retry sleep time to 5 seconds
+// (in an attempt to avoid spamming these sites should we need to retry)
+const RETRY_SLEEP_TIME = 5000;
+
+// populate the test timeout to all available jasmime listeners
+jasmine.getEnv().defaultTimeoutInterval = TEST_TIMEOUT;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = TEST_TIMEOUT;
+
+// create a single instance of price-finder that will be used by e2e tests
+const PriceFinder = require('../../lib/price-finder');
+exports.priceFinder = new PriceFinder({
+  retrySleepTime: RETRY_SLEEP_TIME,
+});
+
+exports.verifyPrice = function verifyPrice(price) {
+  expect(price).toBeDefined();
+
+  // we can't guarantee the price, so just make sure it's a number
+  // that's more than -1
+  expect(price).toBeGreaterThan(-1);
+};
+
+function verifyName(actualName, expectedName) {
+  expect(actualName).toEqual(expectedName);
+}
+
+function verifyCategory(actualCategory, expectedCategory) {
+  expect(actualCategory).toEqual(expectedCategory);
+}
+
+exports.verifyItemDetails = function verifyItemDetails(itemDetails, name, category) {
+  expect(itemDetails).toBeDefined();
+
+  if (itemDetails) {
+    exports.verifyPrice(itemDetails.price);
+    verifyName(itemDetails.name, name);
+    verifyCategory(itemDetails.category, category);
+  }
+};

--- a/test/unit/sites/best-buy-test.js
+++ b/test/unit/sites/best-buy-test.js
@@ -31,12 +31,24 @@ describe('The Best Buy Site', () => {
     }).toThrow();
   });
 
-  it('should throw an exception trying to create a new BestBuySite without an API key', () => {
-    expect(() => {
-      /* eslint-disable no-new */
-      new BestBuySite(VALID_URI, {});
-      /* eslint-enable no-new */
-    }).toThrow();
+  describe('without an API key in the environment', () => {
+    const EXISTING_ENV_KEY = process.env.BESTBUY_KEY;
+
+    beforeEach(() => {
+      process.env.BESTBUY_KEY = '';
+    });
+
+    afterEach(() => {
+      process.env.BESTBUY_KEY = EXISTING_ENV_KEY;
+    });
+
+    it('should throw an exception trying to create a new BestBuySite', () => {
+      expect(() => {
+        /* eslint-disable no-new */
+        new BestBuySite(VALID_URI, {});
+        /* eslint-enable no-new */
+      }).toThrow();
+    });
   });
 
   describe('with an API key in the environment', () => {
@@ -48,7 +60,7 @@ describe('The Best Buy Site', () => {
       process.env.BESTBUY_KEY = '';
     });
 
-    it('should throw an exception trying to create a new BestBuySite without an API key', () => {
+    it('should not throw an exception trying to create a new BestBuySite', () => {
       expect(() => {
         /* eslint-disable no-new */
         new BestBuySite(VALID_URI, {});


### PR DESCRIPTION
Two general things were done in this pull request around the end to end tests:
- Refactor the tests to pull out common function into a `test-helper.js` file.  This includes the environment variable setup for Jasmine, creating a single price-finder instance, and defining a set of helper test functions.  This resolves #53.
- Add the end to end tests to the Travis CI build.  In order to avoid problems, increase the timeout for each e2e test to a _really_ high value, and set the retry sleep time for price finder's scraping utility to a high value (to avoid spamming).  We also had to include the key to access Best Buy in an encrypted format within the .travis.yml file ([reference Travis CI documentation](https://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables)).  This resolves #52.

The document linked below explains how we can have both unit and e2e tests run in parallel, with the unit tests likely to finish first to show early feedback of pull requests:
https://docs.travis-ci.com/user/speeding-up-the-build/#Parallelizing-your-builds-across-virtual-machines

In addition to the changes mentioned above, some additional changes were necessary:
- In the Best Buy unit test, account for the Best Buy key environment variable (after the changes we made above).  Update the test to allow for either case.
- Sleep after each Best Buy end to end test to avoid spamming the API
- Fix a callback error message in price-finder's main library, found in debugging these problems.