### PR TITLE
Switch from request to superagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ When creating a new PriceFinder object, a configuration object can be specified.
 The following options are configurable:
 
 <ul>
-    <li><code>headers</code> : Any HTTP headers that should be sent within the page
-    scrape request. Defaults to <code>"User-Agent": "Mozilla/5.0"</code>.</li>
     <li><code>retryStatusCodes</code> : An array of status codes (Numbers) which
     when returned from the page scrape request, will trigger a retry request
     (meaning it will attempt to scrape the page again). Defaults to

--- a/lib/price-finder.js
+++ b/lib/price-finder.js
@@ -4,7 +4,7 @@ const async = require('async');
 /* eslint-disable prefer-const */
 
 // TODO no const for testing https://github.com/jhnns/rewire/issues/79
-let request = require('request');
+let request = require('superagent');
 /* eslint-enable prefer-const */
 const cheerio = require('cheerio');
 const extend = require('xtend');
@@ -12,9 +12,6 @@ const siteManager = require('./site-manager');
 const logger = require('./logger')();
 
 const DEFAULT_OPTIONS = {
-  headers: {
-    'User-Agent': 'Mozilla/5.0',
-  },
   retryStatusCodes: [503],
   retrySleepTime: 1000,
 };
@@ -159,26 +156,23 @@ class PriceFinder {
 
       // hit the site to get the item details
       (whilstCallback) => {
-        logger.log('using request to get page data for uri: %s', site.getURIForPageData());
-        request({
-          uri: site.getURIForPageData(),
-          headers: this._config.headers,
-        }, (err, response, body) => {
+        logger.log('scraping uri: %s', site.getURIForPageData());
+        request.get(site.getURIForPageData()).end((err, response) => {
           if (err) {
             return whilstCallback(err);
           }
 
           if (response) {
             if (response.statusCode === 200) {
-              logger.log('response statusCode is 200, parsing body to pageData');
+              logger.log('response statusCode is 200, retrieving pageData');
 
-              // good response
+              // pull the page data based on if the site returns JSON
               if (site.isJSON()) {
-                // parse the body to grab the JSON
-                pageData = JSON.parse(body);
+                // grab the body as JSON
+                pageData = response.body;
               } else {
-                // build jquery object using cheerio
-                pageData = cheerio.load(body);
+                // load the text of the page through cheerio
+                pageData = cheerio.load(response.text);
               }
 
               return whilstCallback();

--- a/lib/sites/google-play.js
+++ b/lib/sites/google-play.js
@@ -21,10 +21,7 @@ class GooglePlaySite {
   }
 
   findPriceOnPage($) {
-    // crazy, but this seems to be the way to get the price of an
-    // item on the google play store
-    const priceString = $('.details-actions-right .price').text()
-      .replace(/\s+/g, ' ').split(' ')[1];
+    const priceString = $("*[itemprop='price']").attr('content');
 
     if (!priceString) {
       logger.error('price was not found on google play page, uri: %s', this._uri);

--- a/lib/sites/steam.js
+++ b/lib/sites/steam.js
@@ -21,17 +21,8 @@ class SteamSite {
   }
 
   findPriceOnPage($) {
-    // we need to limit the scope of the query to the first panel
-    const jQuery = $('.game_area_purchase_game').first();
-
-    // the various ways we can find the price
-    const selectors = [
-      '.discount_final_price',
-      '.game_purchase_price',
-    ];
-
     // find the price on the page
-    const priceString = siteUtils.findContentOnPage(jQuery, selectors);
+    const priceString = $("*[itemprop='price']").attr('content');
 
     // were we successful?
     if (!priceString) {
@@ -39,8 +30,8 @@ class SteamSite {
       return -1;
     }
 
-    // process the price string
-    const price = siteUtils.processPrice(priceString);
+    // process the price string as dollars
+    const price = siteUtils.processPrice(`$${priceString}`);
 
     return price;
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "cheerio": "^0.20.0",
     "debug-caller": "^2.0.0",
     "lodash": "^4.3.0",
-    "request": "^2.34.0",
+    "superagent": "^1.7.2",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/test/unit/price-finder-test.js
+++ b/test/unit/price-finder-test.js
@@ -45,17 +45,24 @@ describe('PriceFinder', () => {
       _request = PriceFinder.__get__('request');
 
       // set request to return a specific body
-      PriceFinder.__set__('request', (options, callback) => {
-        // setup valid response
-        const response = {};
-        response.statusCode = 200;
+      const request = {
+        get() {
+          return this;
+        },
 
-        // setup valid body
-        const body = `<div id='actualPriceValue'>$${testPrice}</div>
-            <div id='nav-subnav' data-category='books'>stuff</div>
-            <div id='title'>${testName}</div>`;
-        callback(null, response, body);
-      });
+        end(callback) {
+          // setup valid response
+          const response = {};
+          response.statusCode = 200;
+
+          // setup valid response text
+          response.text = `<div id='actualPriceValue'>$${testPrice}</div>
+              <div id='nav-subnav' data-category='books'>stuff</div>
+              <div id='title'>${testName}</div>`;
+          return callback(null, response);
+        },
+      };
+      PriceFinder.__set__('request', request);
 
       priceFinder = new PriceFinder();
     });
@@ -97,15 +104,22 @@ describe('PriceFinder', () => {
       _request = PriceFinder.__get__('request');
 
       // set request to return a specific body
-      PriceFinder.__set__('request', (options, callback) => {
-        // setup invalid response code
-        const response = {};
-        response.statusCode = 404;
+      const request = {
+        get() {
+          return this;
+        },
 
-        // setup valid body
-        const body = 'Site Not Found';
-        callback(null, response, body);
-      });
+        end(callback) {
+          // setup invalid response code
+          const response = {};
+          response.statusCode = 404;
+
+          // setup valid response text
+          response.text = 'Site Not Found';
+          return callback(null, response);
+        },
+      };
+      PriceFinder.__set__('request', request);
 
       priceFinder = new PriceFinder();
     });
@@ -138,15 +152,22 @@ describe('PriceFinder', () => {
       _request = PriceFinder.__get__('request');
 
       // set request to return a specific body
-      PriceFinder.__set__('request', (options, callback) => {
-        // setup invalid response code
-        const response = {};
-        response.statusCode = 200;
+      const request = {
+        get() {
+          return this;
+        },
 
-        // setup valid body
-        const body = '<h1>Nothin here</h1>';
-        callback(null, response, body);
-      });
+        end(callback) {
+          // setup valid response code
+          const response = {};
+          response.statusCode = 200;
+
+          // setup invalid body
+          response.text = '<h1>Nothin here</h1>';
+          return callback(null, response);
+        },
+      };
+      PriceFinder.__set__('request', request);
 
       priceFinder = new PriceFinder();
     });
@@ -180,35 +201,28 @@ describe('PriceFinder', () => {
     it('should have the default options set', () => {
       const config = priceFinder._config;
       expect(config).toBeDefined();
-      expect(config.headers).toEqual({
-        'User-Agent': 'Mozilla/5.0',
-      });
       expect(config.retryStatusCodes).toEqual([503]);
     });
   });
 
   describe('with options supplied', () => {
     it('should use the correct options', () => {
-      const headers = '123';
       const retryStatusCodes = [300, 301, 302];
       const retrySleepTime = 4000;
       let priceFinder;
 
       // override some, but not all...
       priceFinder = new PriceFinder({
-        headers,
+        retrySleepTime,
       });
-      expect(priceFinder._config.headers).toEqual(headers);
       expect(priceFinder._config.retryStatusCodes).toEqual([503]);
-      expect(priceFinder._config.retrySleepTime).toEqual(1000);
+      expect(priceFinder._config.retrySleepTime).toEqual(retrySleepTime);
 
       // override all
       priceFinder = new PriceFinder({
-        headers,
         retryStatusCodes,
         retrySleepTime,
       });
-      expect(priceFinder._config.headers).toEqual(headers);
       expect(priceFinder._config.retryStatusCodes).toEqual(retryStatusCodes);
       expect(priceFinder._config.retrySleepTime).toEqual(retrySleepTime);
     });

--- a/test/unit/sites/google-play-test.js
+++ b/test/unit/sites/google-play-test.js
@@ -63,12 +63,7 @@ describe('The GooglePlay Site', () => {
 
         $ = cheerio.load(
           `<title>Big - Movies & TV on Google Play</title>
-           <div class='details-actions-right'>
-           <div class='price'>
-           <span> $${price}</span>
-           <span> something </span>
-           </div>
-           </div>
+           <meta content="$${price}" itemprop="price">
            <div class='details-info'>
            <div class='document-title'>Big</div></div>`);
         bad$ = cheerio.load('<h1>Nothin here</h1>');

--- a/test/unit/sites/steam-test.js
+++ b/test/unit/sites/steam-test.js
@@ -62,34 +62,15 @@ describe('The Steam Site', () => {
         name = 'Cool Game';
 
         $ = cheerio.load(`
-          <div class='game_area_purchase_game'>
-            <div class='game_purchase_price'>
-              $${price}
-            </div>
-            <div class='apphub_AppName'>
-              ${name}
-            </div>
-          </div>'
-          <div class='game_area_purchase_game'>
-            <div class='game_purchase_price'>
-              $999.99
-            </div>
-          </div>'
+          <div class='apphub_AppName'>
+            ${name}
+          </div>
+          <meta itemprop="price" content="${price}">
         `);
         bad$ = cheerio.load('<h1>Nothin here</h1>');
       });
 
       it('should return the price when displayed on the page', () => {
-        const priceFound = site.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
-      });
-
-      it('should return the price when discounted on the page', () => {
-        $ = cheerio.load(`
-          <div class='game_area_purchase_game'>
-            <div class='discount_final_price'>$${price}</div>
-          </div>
-        `);
         const priceFound = site.findPriceOnPage($);
         expect(priceFound).toEqual(price);
       });


### PR DESCRIPTION
Replace the node module `request` with `superagent`.  Doing so seems to have greatly improved the reliability of the responses as well as the detail returned (at least in tests of the existing site pages).  We’re no longer seeing all the 503 responses (which were seen a lot on Amazon) and we’re able to get additional page content which makes some of the sites price queries easier.

In issue #63 a few sites were listed as tests to see if we could improve the page response data enough to help those example pages. Newegg still seems to mask their price data too much to allow a single request to return the price as it is displayed on a rendered page. Upon further investigation, if one was to view the page source of a Newegg site, the price data is not included.  This leads one to believe the price data is loaded on the page after the initial load with JavaScript.

The test for flipkart had more success, returning the price data through a simple query after the page load (`$("*[itemprop='price']").attr('content')`).

A downside to this implementation is that request headers are not as simple as they were with the `request` module.  However, since none of the sites were utilizing this feature, and the flipkart site can use scraping directly, I would rather include this when required rather than build functionality without a customer.  This is a breaking change though.  But I feel the pros (read above) greatly outweigh this con.

For reference, TravisCI build times were cut in half, from 5 minutes to 2 minutes.