### PR TITLE
Best Buy supports both scraping and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![NPM](https://nodei.co/npm/price-finder.svg?downloads=true)](https://nodei.co/npm/price-finder/)
 
 The price-finder module helps find the price of retail items online, either
-through scraping the product page or through product APIs (optionally able to
-find the name and category of products as well).
+through scraping the product page or through product APIs (also able to
+find the name and category of products).
 
 price-finder supports Node v4.x and above.
 
@@ -15,50 +15,34 @@ price-finder supports Node v4.x and above.
 ### Find an item's current price online ###
 
 ```javascript
-const PriceFinder = require("price-finder");
-
+const PriceFinder = require('price-finder');
 const priceFinder = new PriceFinder();
 
 // Atoms for Peace : Amok  (from Amazon)
-const uri = "http://www.amazon.com/Amok/dp/B00BIQ1EL4";
+const uri = 'http://www.amazon.com/Amok/dp/B00BIQ1EL4';
 priceFinder.findItemPrice(uri, function(err, price) {
     console.log(price); // 8.91
 });
 ```
-### Find an item's current price using service that requires API key ###
+### Find the price, name, and category of an item online ###
 
 ```javascript
-const PriceFinder = require("price-finder");
-
-const priceFinder = new PriceFinder({keys:{bestbuy:"Key from developer.bestbuy.com"}});
-
-// Ferris Bueller's Day Off  (from BestBuy)
-const uri = "http://www.bestbuy.com/site/ferris-buellers-day-off-dvd/7444513.p?id=47476&skuId=7444513";
-priceFinder.findItemPrice(uri, function(err, price) {
-    console.log(price); // 3.99
-});
-
-```
-### Find additional details on an item, including price ###
-
-```javascript
-const PriceFinder = require("price-finder");
-
+const PriceFinder = require('price-finder');
 const priceFinder = new PriceFinder();
 
 // Plants vs Zombies  (from Google Play)
-let uri = "https://play.google.com/store/apps/details?id=com.popcap.pvz_na";
+let uri = 'https://play.google.com/store/apps/details?id=com.popcap.pvz_na';
 priceFinder.findItemDetails(uri, function(err, itemDetails) {
     console.log(itemDetails.price);    // 0.99
     console.log(itemDetails.name);     // Plants vs. Zombies™
     console.log(itemDetails.category); // Mobile Apps
 });
 
-// PixelJunk Monsters  (from Sony Entertainment Network / Playstation Store)
-uri = "https://store.playstation.com/#!/en-us/games/pixeljunk-monsters/cid=UP9000-NPUA80108_00-PJMONSTSFULL0001";
+// Don't Starve  (from Steam)
+uri = 'http://store.steampowered.com/app/219740';
 priceFinder.findItemDetails(uri, function(err, itemDetails) {
-    console.log(itemDetails.price);    // 9.99
-    console.log(itemDetails.name);     // PixelJunk™ Monsters
+    console.log(itemDetails.price);    // 14.99
+    console.log(itemDetails.name);     // Don't Starve
     console.log(itemDetails.category); // Video Games
 });
 ```
@@ -80,35 +64,20 @@ priceFinder.findItemDetails(uri, function(err, itemDetails) {
 When creating a new PriceFinder object, a configuration object can be specified.
 The following options are configurable:
 
-<ul>
-    <li><code>retryStatusCodes</code> : An array of status codes (Numbers) which
-    when returned from the page scrape request, will trigger a retry request
-    (meaning it will attempt to scrape the page again). Defaults to
-    <code>[503]</code>.</li>
-    <li><code>retrySleepTime</code> : If a retry status code is returned from a
-    page scrape request, this is the amount of time (in milliseconds) that the
-    code will sleep prior to re-issuing the request. Defaults to
-    <code>1000</code> (ms).</li>
-    <li><code>keys</code> : An object of API keys required by services dependent upon keys. The following is the complete list of API services requiring keys:
-    <table><thead><tr><th>Service</th><th>Object Key</th><th>Environment Variable Override</th></tr></thead>
-    <tbody>
-        <tr>
-            <td><a href="https://developer.bestbuy.com">Best Buy</a></td><td><code>bestbuy</code></td><td><code>BESTBUY_KEY</code></td></tr>
-    </tbody>
-    </table>
-    </li>
-</ul>
+- `retryStatusCodes` : An array of status codes (Numbers) which when returned
+from the page scrape request, will trigger a retry request (meaning it will
+attempt to scrape the page again). Defaults to `[503]`.
+- `retrySleepTime` : If a retry status code is returned from a page scrape
+request, this is the amount of time (in milliseconds) that the code will sleep
+prior to re-issuing the request. Defaults to `1000` (ms).
 
 For example:
 
 ```javascript
-const PriceFinder = require("price-finder");
+const PriceFinder = require('price-finder');
 
 const priceFinder = new PriceFinder({
   retrySleepTime: 2000,
-  keys: {
-    "sampleService": "abc123"
-  },
 });
 ```
 
@@ -117,33 +86,25 @@ const priceFinder = new PriceFinder({
 #### findItemPrice(`uri`, `callback`) ####
 
 Given a `uri` (that is for a [supported site](#supported-sites)), this
-function will scrape the page and attempt to find the current price listed on the page,
-sending it to the `callback`. The `callback`'s arguments are:
-<ul>
-    <li><code>error</code> : If an error occurred during processing, this will contain
-    the error information. If no errors occurred, this will be <code>null</code>.</li>
-    <li><code>price</code> : The current price of the item listed on the page (a
-    <code>Number</code>).</li>
-</ul>
+function will scrape the page and attempt to find the current price listed on
+the page, sending it to the `callback`. The `callback`'s arguments are:
+
+- `error` : If an error occurred during processing, this will contain the error
+information. If no errors occurred, this will be `null`.
+- `price` : The current price of the item listed on the page (a `Number`).
 
 #### findItemDetails(`uri`, `callback`) ####
 
 Given a `uri` (that is for a [supported site](#supported-sites)), this
-function will scrape the page and attempt to find the item details listed on the page,
-sending it to the `callback`. The `callback`'s arguments are:
-<ul>
-<li><code>error</code> : If an error occurred during processing, this will contain
-the error information. If no errors occurred, this will be <code>null</code>.</li>
-<li><code>itemDetails</code> : This object contains three things:
-    <ul>
-        <li><code>price</code> : The current price of the item listed on the page (a
-        <code>Number</code>).</li>
-        <li><code>name</code> : The name of the product (if supported by the site
-        implementation).</li>
-        <li><code>category</code> : The category of the product (if supported by
-        the site implementation).</li>
-    </ul>
-</ul>
+function will scrape the page and attempt to find the item details listed on
+the page, sending it to the `callback`. The `callback`'s arguments are:
+
+- `error` : If an error occurred during processing, this will contain the error
+information. If no errors occurred, this will be `null`.
+- `itemDetails` : This object contains three things:
+  - `price` : The current price of the item listed on the page (a `Number`).
+  - `name` : The name of the product (if supported by the site implementation).
+  - `category` : The category of the product (if supported by the site implementation).
 
 ### Debugging Price Finder ###
 
@@ -153,7 +114,9 @@ down any potential issues. To enable, export the `DEBUG` environment
 variable set to `price-finder*` to pick up all files (or include a
 specific library to only enable a certain module). For example:
 
-`$ DEBUG=price-finder* node app.js`
+```
+$ DEBUG=price-finder* node app.js
+```
 
 ### Supported Sites ###
 
@@ -162,6 +125,9 @@ The current supported sites are listed below.
 - Amazon (support for more than just .com)
 - Google Play
 - Best Buy
+  - API support is available, enabled when the `BESTBUY_KEY` environment variable
+  is populated with an API key. For more information on how to obtain an API key,
+  refer to the [Best Buy developer documentation](https://developer.bestbuy.com).
 - Sony Playstation
 - GameStop
 - Crutchfield
@@ -180,7 +146,9 @@ The price-finder project is a [Node.js](http://nodejs.org/) module, so before
 cloning the repository make sure node is installed. Once cloned, install dependencies
 by issuing:
 
-`$ npm install`
+```
+$ npm install
+```
 
 #### Tests ####
 
@@ -191,36 +159,38 @@ for any new features).
 
 To run the unit tests execute:
 
-`$ npm test`
+```
+$ npm test
+```
 
-These tests can be run in watch mode, listening for any file changes and re-running when
-that occurs. To do so execute:
+These tests can be run in watch mode, listening for any file changes and
+re-running when that occurs. To do so execute:
 
-`$ npm run test-watch`
+```
+$ npm run test-watch
+```
 
 ##### End To End Tests #####
 
-End-to-end tests exist which will test the price-finder module using real URIs, scraping
-the pages to verify the code works correctly. Because these tests can take a while to run,
-debug logging has been enabled in the npm script.
+End-to-end tests exist which will test the price-finder module using real URIs,
+scraping the pages to verify the code works correctly. Because these tests can
+take a while to run, debug logging has been enabled in the npm script.
 
-The end to end tests for Best Buy require a developer API key available in the
-environment via the `BESTBUY_KEY` environment variable. For more information, please consult
-the site: https://developer.bestbuy.com.
-
-_Note that these tests should be run on a limited basis while coding since some sites have
-been known to throw up CAPTCHA's after repeated, automated page requests._
+_Note that these tests should be run on a limited basis while coding since some
+sites have been known to throw up CAPTCHA's after repeated, automated page requests._
 
 To execute the end to end tests run:
 
-`$ BESTBUY_KEY=<key> npm run test-e2e`
-
-Where `<key>` is the developer API key for Best Buy.
+```
+$ npm run test-e2e
+```
 
 If you would like to run a single end to end test (rather than all of them),
 use the `test-e2e-single` script. For example:
 
-`$ npm run test-e2e-single test/e2e/amazon-uris-test.js`
+```
+$ npm run test-e2e-single test/e2e/amazon-uris-test.js
+```
 
 #### Adding Sites ####
 

--- a/lib/sites/best-buy.js
+++ b/lib/sites/best-buy.js
@@ -4,7 +4,7 @@ const siteUtils = require('../site-utils');
 const logger = require('../logger')();
 
 class BestBuySite {
-  constructor(uri, config) {
+  constructor(uri) {
     // error check to make sure this is a valid uri for Best Buy
     if (!BestBuySite.isSite(uri)) {
       throw new Error('invalid uri for Best Buy: %s', uri);
@@ -12,44 +12,41 @@ class BestBuySite {
 
     this._uri = uri;
 
-    // attempt to find the API key
-    if (config.keys && config.keys.bestbuy) {
-      this.api_key = config.keys.bestbuy;
-    }
-
-    // allow the environment variable to override the config
+    // if the user supplies an API key, use it (instead of scraping)
     if (!!process.env.BESTBUY_KEY) {
-      this.api_key = process.env.BESTBUY_KEY;
-    }
-
-    // if we still don't have an API key, abort!
-    if (!this.api_key) {
-      const errorMessage = 'Best Buy cannot be called unless an API key is provided';
-      logger.error(errorMessage);
-      throw new Error(errorMessage);
+      this._apiKey = process.env.BESTBUY_KEY;
     }
   }
 
-    isJSON() {
+  isJSON() {
+    // if we have an API key, then yes, the site returns JSON
+    if (this._apiKey) {
       return true;
+    } else {
+      return false;
     }
+  }
 
-    getURIForPageData() {
+  getURIForPageData() {
+    if (this._apiKey) {
+      // if we have an API key, determine the API from the URI
       const sku = /skuId=(\d+)/.exec(this._uri);
       if (!sku || !sku[1]) {
         logger.error('Could not detect the SKU from the URL');
         return null;
       }
 
-      /* eslint-disable prefer-template */
-      return 'https://api.remix.bestbuy.com/v1/products/' +
-        sku[1] +
-        '.json?show=sku,name,salePrice,categoryPath&apiKey=' +
-        this.api_key;
-      /* eslint-enable prefer-template */
+      return `https://api.remix.bestbuy.com/v1/products/${sku[1]}` +
+        `.json?show=sku,name,salePrice,categoryPath&apiKey=${this._apiKey}`;
+    } else {
+      // else it's a normal page scrape, use the original URI
+      return this._uri;
     }
+  }
 
-    findPriceOnPage(pageData) {
+  findPriceOnPage($) {
+    if (this._apiKey) {
+      const pageData = $;
       if (typeof pageData !== 'object' || !pageData.salePrice) {
         return -1;
       }
@@ -61,62 +58,99 @@ class BestBuySite {
        * siteUtils.processPrice on this salePrice, but instead just return it.
        */
       return pageData.salePrice;
-    }
+    } else {
+      const priceString = $("*[itemprop='price']").attr('content');
 
-    findCategoryOnPage(pageData) {
+      if (!priceString) {
+        logger.error('price not found on BestBuy page, uri: %s', this._uri);
+        return -1;
+      }
+
+      // process the price string as dollars
+      const price = siteUtils.processPrice(`$${priceString}`);
+
+      return price;
+    }
+  }
+
+  findCategoryOnPage($) {
+    let category;
+    let rawCategory;
+    let parentCategory;
+
+    if (this._apiKey) {
+      const pageData = $;
       if (typeof pageData !== 'object') {
         return null;
       }
 
-      if (pageData.categoryPath.length < 2) {
+      if (pageData.categoryPath.length < 3) {
         logger.error('category not found on best buy page, uri: %s', this._uri);
         return null;
       }
 
-      const rawCategory = pageData.categoryPath[1].name;
-
-      logger.log('raw category found: %s', rawCategory);
-
-      let category;
-      if (rawCategory === 'Movies & Music') {
-        // need to figure out which one: Movies or Music
-        const parentCategory = pageData.categoryPath[2].name;
-
-        logger.log('raw parentCategory: %s', parentCategory);
-
-        if (parentCategory.indexOf('Movies') > -1) {
-          category = siteUtils.categories.MOVIES_TV;
-        } else {
-          // assume (generic) Music if not Movies
-          category = siteUtils.categories.MUSIC;
-        }
-      } else if (rawCategory === 'Video Games') {
-        category = siteUtils.categories.VIDEO_GAMES;
-      } else {
-        logger.log('category not setup, using "other"');
-        category = siteUtils.categories.OTHER;
-      }
-
-      logger.log('category: %s', category);
-
-      return category;
+      rawCategory = pageData.categoryPath[1].name;
+      parentCategory = pageData.categoryPath[2].name;
+    } else {
+      rawCategory = $('#analytics-data').attr('data-uber-cat-name');
+      parentCategory = $('#analytics-data').attr('data-parent-cat-name');
     }
 
-    findNameOnPage(pageData) {
+    logger.log('rawCategory: %s', rawCategory);
+    logger.log('parentCategory: %s', parentCategory);
+
+    if (rawCategory === 'Movies & Music') {
+      // need to figure out which one: Movies or Music
+      if (parentCategory.indexOf('Movies') > -1) {
+        category = siteUtils.categories.MOVIES_TV;
+      } else {
+        // assume (generic) Music if not Movies
+        category = siteUtils.categories.MUSIC;
+      }
+    } else if (rawCategory === 'Video Games') {
+      category = siteUtils.categories.VIDEO_GAMES;
+    } else {
+      logger.log('category not setup, using "other"');
+      category = siteUtils.categories.OTHER;
+    }
+
+    logger.log('category: %s', category);
+
+    return category;
+  }
+
+  findNameOnPage($) {
+    let name;
+
+    if (this._apiKey) {
+      const pageData = $;
+
       if (typeof pageData !== 'object') {
         return null;
       }
 
-      return pageData.name;
-    }
+      name = pageData.name;
+    } else {
+      name = $('#sku-title[itemprop="name"]').text();
 
-    static isSite(uri) {
-      if (uri.indexOf('bestbuy.com') > -1) {
-        return true;
-      } else {
-        return false;
+      if (!name) {
+        logger.error('name not found on BestBuy page, uri: %s', this._uri);
+        return null;
       }
     }
+
+    logger.log('name: %s', name);
+
+    return name;
+  }
+
+  static isSite(uri) {
+    if (uri.indexOf('bestbuy.com') > -1) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }
 
 module.exports = BestBuySite;

--- a/test/e2e/best-buy-uris-test.js
+++ b/test/e2e/best-buy-uris-test.js
@@ -7,80 +7,86 @@ const verifyPrice = testHelper.verifyPrice;
 const verifyItemDetails = testHelper.verifyItemDetails;
 
 /*
- * To avoid spamming the API, sleep a bit between tests
+ * These tests work with an API key and without. If we have an API key, then we
+ * should use it in some of the tests to verify the API works. But we only want
+ * to do that if it's available. We also want to (always) verify the default
+ * scraping behavior without the API key.
  */
-function waitForDone(done) {
-  setTimeout(() => done(), 5000);
-}
 
 describe('price-finder for Best Buy URIs', () => {
-  it('should have the API key defined', (done) => {
-    expect(process.env.BESTBUY_KEY).toBeDefined();
-    done();
-  });
+  describe('attemping to verify the API (if API key is available)', () => {
+    function waitForDone(done) {
+      // if we're using the API, to avoid spamming, sleep a bit between tests
+      setTimeout(() => done(), process.env.BESTBUY_KEY ? 5000 : 0);
+    }
 
-  // Music
-  describe('testing a Music item', () => {
-    // Blues Brothers: Briefcase Full of Blues
-    const uri = 'http://www.bestbuy.com/site/briefcase-full-of-blues-cd/17112312.p?id=1889657&skuId=17112312';
+    // Music
+    describe('testing a Music item', () => {
+      // Blues Brothers: Briefcase Full of Blues
+      const uri = 'http://www.bestbuy.com/site/briefcase-full-of-blues-cd/17112312.p?id=1889657&skuId=17112312';
 
-    it('should respond with a price for findItemPrice()', (done) => {
-      priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
-        verifyPrice(price);
-        waitForDone(done);
+      it('should respond with a price for findItemPrice()', (done) => {
+        priceFinder.findItemPrice(uri, (err, price) => {
+          expect(err).toBeNull();
+          verifyPrice(price);
+          waitForDone(done);
+        });
       });
-    });
 
-    it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
-      priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
-        verifyItemDetails(itemDetails, 'Briefcase Full of Blues - CD', 'Music');
-        waitForDone(done);
-      });
-    });
-  });
-
-  // Movies & TV
-  describe('testing a Movies & TV item', () => {
-    // Ferris Bueller's Day Off
-    const uri = 'http://www.bestbuy.com/site/ferris-buellers-day-off-dvd/7444513.p?id=47476&skuId=7444513';
-
-    it('should respond with a price for findItemPrice()', (done) => {
-      priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
-        verifyPrice(price);
-        waitForDone(done);
-      });
-    });
-
-    it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
-      priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
-        verifyItemDetails(itemDetails, 'Ferris Bueller\'s Day Off (DVD)', 'Movies & TV');
-        waitForDone(done);
+      it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
+        priceFinder.findItemDetails(uri, (err, itemDetails) => {
+          expect(err).toBeNull();
+          verifyItemDetails(itemDetails, 'Briefcase Full of Blues - CD', 'Music');
+          waitForDone(done);
+        });
       });
     });
   });
 
-  // Video Games
-  describe('testing a Video Games item', () => {
-    // Super Mario 3D Land
-    const uri = 'http://www.bestbuy.com/site/super-mario-3d-land-nintendo-3ds/2809399.p?id=1218353391490&skuId=2809399';
+  describe('verify scraping (without the use of the API)', () => {
+    const EXISTING_ENV_KEY = process.env.BESTBUY_KEY;
 
-    it('should respond with a price for findItemPrice()', (done) => {
-      priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
-        verifyPrice(price);
-        waitForDone(done);
+    beforeEach(() => {
+      process.env.BESTBUY_KEY = '';
+    });
+
+    afterEach(() => {
+      process.env.BESTBUY_KEY = EXISTING_ENV_KEY;
+    });
+
+    // Movies & TV
+    describe('testing a Movies & TV item', () => {
+      // Ferris Bueller's Day Off
+      const uri = 'http://www.bestbuy.com/site/ferris-buellers-day-off-dvd/7444513.p?id=47476&skuId=7444513';
+
+      it('should respond with a price for findItemPrice()', (done) => {
+        priceFinder.findItemPrice(uri, (err, price) => {
+          expect(err).toBeNull();
+          verifyPrice(price);
+          done();
+        });
+      });
+
+      it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
+        priceFinder.findItemDetails(uri, (err, itemDetails) => {
+          expect(err).toBeNull();
+          verifyItemDetails(itemDetails, 'Ferris Bueller\'s Day Off (DVD) (Eng/Fre) 1986', 'Movies & TV');
+          done();
+        });
       });
     });
 
-    it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
-      priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
-        verifyItemDetails(itemDetails, 'Super Mario 3D Land - Nintendo 3DS', 'Video Games');
-        waitForDone(done);
+    // Video Games
+    describe('testing a Video Games item', () => {
+      // Super Mario 3D Land
+      const uri = 'http://www.bestbuy.com/site/super-mario-3d-land-nintendo-3ds/2809399.p?id=1218353391490&skuId=2809399';
+
+      it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
+        priceFinder.findItemDetails(uri, (err, itemDetails) => {
+          expect(err).toBeNull();
+          verifyItemDetails(itemDetails, 'Super Mario 3D Land - Nintendo 3DS', 'Video Games');
+          done();
+        });
       });
     });
   });

--- a/test/e2e/flipkart-uris-test.js
+++ b/test/e2e/flipkart-uris-test.js
@@ -8,7 +8,7 @@ const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for Flipkart Store URIs', () => {
   describe('testing Nexus 6 item', () => {
-    const uri = 'http://www.flipkart.com/nexus-6/p/itme7zd6w6qwgjuy?pid=MOBEFHHGZFKAZKY3';
+    const uri = 'http://www.flipkart.com/apple-iphone-6/p/itme8dvfeuxxbm4r?pid=MOBEYHZ2YAXZMF2J';
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
@@ -21,7 +21,7 @@ describe('price-finder for Flipkart Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         expect(err).toBeNull();
-        verifyItemDetails(itemDetails, 'Nexus 6', 'Other');
+        verifyItemDetails(itemDetails, 'Apple iPhone 6', 'Other');
         done();
       });
     });

--- a/test/unit/sites/best-buy-test.js
+++ b/test/unit/sites/best-buy-test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const BestBuySite = require('../../../lib/sites/best-buy');
+const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
 
 const VALID_URI = 'http://www.bestbuy.com/site/product?skuId=123';
 const INVALID_URI = 'http://www.bad.com/123/product';
-const TRANSLATED_URI = 'https://api.remix.bestbuy.com/v1/products/123.json?show=sku,name,salePrice,categoryPath&apiKey=junkKey';
-const CONFIG = { keys: { bestbuy: 'junkKey' } };
+const TRANSLATED_URI = 'https://api.remix.bestbuy.com/v1/products/123.json?show=sku,name,salePrice,categoryPath&apiKey=123';
 
 describe('The Best Buy Site', () => {
   it('should exist', () => {
@@ -26,34 +26,102 @@ describe('The Best Buy Site', () => {
   it('should throw an exception trying to create a new BestBuySite with an incorrect uri', () => {
     expect(() => {
       /* eslint-disable no-new */
-      new BestBuySite(INVALID_URI, CONFIG);
+      new BestBuySite(INVALID_URI);
       /* eslint-enable no-new */
     }).toThrow();
   });
 
   describe('without an API key in the environment', () => {
+    let site;
     const EXISTING_ENV_KEY = process.env.BESTBUY_KEY;
 
     beforeEach(() => {
       process.env.BESTBUY_KEY = '';
+
+      site = new BestBuySite(VALID_URI);
     });
 
     afterEach(() => {
       process.env.BESTBUY_KEY = EXISTING_ENV_KEY;
     });
 
-    it('should throw an exception trying to create a new BestBuySite', () => {
+    it('should not throw an exception trying to create a new BestBuySite', () => {
       expect(() => {
         /* eslint-disable no-new */
-        new BestBuySite(VALID_URI, {});
+        new BestBuySite(VALID_URI);
         /* eslint-enable no-new */
-      }).toThrow();
+      }).not.toThrow();
+    });
+
+    it('should exist', () => {
+      expect(site).toBeDefined();
+    });
+
+    it('should return the same URI for getURIForPageData()', () => {
+      expect(site.getURIForPageData()).toEqual(VALID_URI);
+    });
+
+    it('should return false for isJSON()', () => {
+      expect(site.isJSON()).toBeFalsy();
+    });
+
+    describe('with a populated page', () => {
+      let $;
+      let bad$;
+      let price;
+      let category;
+      let name;
+
+      beforeEach(() => {
+        price = 2.99;
+        category = siteUtils.categories.MUSIC;
+        name = 'Awesome Product';
+
+        $ = cheerio.load(`
+          <meta itemprop="price" content="${price}">
+          <div id="analytics-data"
+            data-uber-cat-name="Movies & Music"
+            data-parent-cat-name="Music (CDs & Vinyl): R&B & Soul">
+          </div>
+          <div id="sku-title" itemprop="name">${name}</div>
+        `);
+        bad$ = cheerio.load('<h1>Nothin here</h1>');
+      });
+
+      it('should return the price when displayed on the page', () => {
+        const priceFound = site.findPriceOnPage($);
+        expect(priceFound).toEqual(price);
+      });
+
+      it('should return -1 when the price is not found', () => {
+        const priceFound = site.findPriceOnPage(bad$);
+        expect(priceFound).toEqual(-1);
+      });
+
+      it('should always return the category', () => {
+        const categoryFound = site.findCategoryOnPage($);
+        expect(categoryFound).toEqual(category);
+      });
+
+      it('should return the name when displayed on the page', () => {
+        const nameFound = site.findNameOnPage($, category);
+        expect(nameFound).toEqual(name);
+      });
+
+      it('should return null when the name is not displayed on the page', () => {
+        const nameFound = site.findNameOnPage(bad$, category);
+        expect(nameFound).toEqual(null);
+      });
     });
   });
 
   describe('with an API key in the environment', () => {
+    let bestBuy;
+
     beforeEach(() => {
       process.env.BESTBUY_KEY = '123';
+
+      bestBuy = new BestBuySite(VALID_URI);
     });
 
     afterEach(() => {
@@ -66,14 +134,6 @@ describe('The Best Buy Site', () => {
         new BestBuySite(VALID_URI, {});
         /* eslint-enable no-new */
       }).not.toThrow();
-    });
-  });
-
-  describe('a new Best Buy Site', () => {
-    let bestBuy;
-
-    beforeEach(() => {
-      bestBuy = new BestBuySite(VALID_URI, CONFIG);
     });
 
     it('should exist', () => {

--- a/test/unit/sites/mock-data/bestbuy-other_category.json
+++ b/test/unit/sites/mock-data/bestbuy-other_category.json
@@ -5,5 +5,8 @@
   }, {
     "id": "other123",
     "name": "Unrecognized Category"
+  }, {
+    "id": "other456",
+    "name": "Unrecognized Category"
   }]
 }


### PR DESCRIPTION
Refactor the Best Buy site implementation to support both the API path and the scraping path.  If the API key is available as an environment variable, we’ll use the API to query for product details.  If however it’s not available, then we support scraping the site for the details as well.  This should allow for both those who want to use the API but not restrict those who do not have an API key.

A breaking change is that we no longer support supplying the API key through the configuration of the `PriceFinder` object.  To simplify things, this API key can now only be supplied through an environment variable (which most should use anyway to avoid committing the API key to source control).

Update the tests to account for the changes.  The unit tests check both the API and scraping path.  The end to end tests will check the API path if the API key is available.  It will always check the scraping path.  This was done to avoid problems when the API key is not available for the test user (especially for TravisCI pull requests on forks who do not have access to the API key).  This should close #73.

Update the readme to clean up some of the data now that Best Buy no longer requires an API key, and it can no longer be supplied via the configuration (only as an environment variable).  Update some other content to clean things up a bit.

Finally, update the e2e test item for Flipkart since the previous item was not returning data.  Hopefully this one has more availability.