### PR TITLE
Move from Jasmine to Mocha

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,24 +15,18 @@ module.exports = function exports(grunt) {
         DEBUG: 'price-finder*',
       },
     },
-    jasmine_nodejs: {
-      options: {
-        specNameSuffix: 'test.js',
-        reporters: {
-          console: {
-            colors: true,
-            cleanStack: true,
-            verbosity: true,
-            listStyle: 'indent',
-            activity: false,
-          },
-        },
-      },
+    mochaTest: {
       unit: {
-        specs: ['test/unit/**'],
+        src: ['test/unit/**/*test.js'],
       },
       e2e: {
-        specs: ['test/e2e/**'],
+        options: {
+          reporter: 'list',
+
+          // set the timeout for each test to 60 seconds (crazy! but necessary it seems)
+          timeout: 60000,
+        },
+        src: ['test/e2e/**/*test.js'],
       },
     },
   });
@@ -40,6 +34,6 @@ module.exports = function exports(grunt) {
   // load all the grunt tasks at once
   require('load-grunt-tasks')(grunt);
 
-  grunt.registerTask('test', ['eslint', 'jasmine_nodejs:unit']);
-  grunt.registerTask('e2e', ['env:e2e', 'jasmine_nodejs:e2e']);
+  grunt.registerTask('test', ['eslint', 'mochaTest:unit']);
+  grunt.registerTask('e2e', ['env:e2e', 'mochaTest:e2e']);
 };

--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ $ npm install
 
 #### Tests ####
 
-The project uses [Jasmine](http://jasmine.github.io/) for tests (please add
+The project uses the [Mocha test framework](https://mochajs.org/) along with
+the [Should assertion library](http://shouldjs.github.io/) for tests (please add
 tests for any new features).
 
 ##### Unit Tests #####

--- a/lib/price-finder.js
+++ b/lib/price-finder.js
@@ -1,11 +1,7 @@
 'use strict';
 
 const async = require('async');
-/* eslint-disable prefer-const */
-
-// TODO no const for testing https://github.com/jhnns/rewire/issues/79
-let request = require('superagent');
-/* eslint-enable prefer-const */
+const request = require('superagent');
 const cheerio = require('cheerio');
 const extend = require('xtend');
 const siteManager = require('./site-manager');

--- a/lib/sites/greenman-gaming.js
+++ b/lib/sites/greenman-gaming.js
@@ -21,11 +21,11 @@ class GreenmanGamingSite {
   }
 
   findPriceOnPage($) {
-    let currencyTag = '';
-    let productJson = '';
+    let currencyTag;
+    let productJson;
+
     // To find Currency
-    // TODO Do the same with regex!
-    $('script').each(function () {
+    $('script').each(function loadProductJson() {
       currencyTag = $(this).text().trim();
       if (currencyTag.indexOf('var utag_data') !== -1) {
         productJson = currencyTag.substring(currencyTag.indexOf('{'), currencyTag.length - 1);
@@ -33,10 +33,17 @@ class GreenmanGamingSite {
       }
     });
 
+    // without the productJson, we're unable to find the price
+    if (!productJson) {
+      logger.error('price not found on GreenmanGaming page, uri: %s', this._uri);
+      return -1;
+    }
+
     const currency = productJson.currency_code;
     const priceString = productJson.product_price_readable;
+
     // were we successful?
-    if (!priceString) {
+    if (!priceString || !currency) {
       logger.error('price not found on GreenmanGaming page, uri: %s', this._uri);
       return -1;
     }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "prepublish": "npm prune",
     "test": "grunt test",
     "test-e2e": "grunt e2e",
-    "test-watch": "jasmine-node --test-dir test/unit --matchall --color --autotest --watch lib",
-    "test-e2e-single": "DEBUG=price-finder* jasmine-node --matchall --color --verbose --noStack $1"
+    "test-watch": "mocha --colors --watch --recursive test/unit",
+    "test-e2e-single": "DEBUG=price-finder* mocha --colors --reporter list $1"
   },
   "dependencies": {
     "accounting": "^0.4.0",
@@ -54,15 +54,17 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^5.0.0",
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-env": "^0.4.4",
     "grunt-eslint": "^17.3.1",
-    "grunt-jasmine-nodejs": "^1.4.3",
-    "jasmine-node": "^1.14.3",
+    "grunt-mocha-test": "^0.12.7",
     "load-grunt-tasks": "^3.2.0",
-    "rewire": "^2.0.0"
+    "mocha": "^2.4.5",
+    "proxyquire": "^1.7.4",
+    "should": "^8.2.2"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,5 @@
 {
   "env": {
-    "jasmine": true
+    "mocha": true
   }
 }

--- a/test/e2e/amazon-uris-test.js
+++ b/test/e2e/amazon-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -20,7 +21,7 @@ describe('price-finder for Amazon URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -28,7 +29,7 @@ describe('price-finder for Amazon URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Coldplay: A Rush Of Blood To The Head', 'Digital Music');
         done();
       });
@@ -46,7 +47,7 @@ describe('price-finder for Amazon URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Pikmin 3', 'Video Games');
         done();
       });
@@ -60,7 +61,7 @@ describe('price-finder for Amazon URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Minecraft - Pocket Edition', 'Mobile Apps');
         done();
       });
@@ -74,7 +75,7 @@ describe('price-finder for Amazon URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'The Blues Brothers [Blu-ray]', 'Movies & TV');
         done();
       });
@@ -88,7 +89,7 @@ describe('price-finder for Amazon URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Origins: Fourteen Billion Years of Cosmic Evolution', 'Books');
         done();
       });
@@ -102,7 +103,7 @@ describe('price-finder for Amazon URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
 
         // Amazon reports 'apparel' for luggage, so we default to 'other'
         verifyItemDetails(itemDetails, 'eBags TLS Mother Lode Mini 21" Wheeled Duffel', 'Other');

--- a/test/e2e/best-buy-uris-test.js
+++ b/test/e2e/best-buy-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -27,7 +28,7 @@ describe('price-finder for Best Buy URIs', () => {
 
       it('should respond with a price for findItemPrice()', (done) => {
         priceFinder.findItemPrice(uri, (err, price) => {
-          expect(err).toBeNull();
+          should(err).be.null();
           verifyPrice(price);
           waitForDone(done);
         });
@@ -35,7 +36,7 @@ describe('price-finder for Best Buy URIs', () => {
 
       it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
         priceFinder.findItemDetails(uri, (err, itemDetails) => {
-          expect(err).toBeNull();
+          should(err).be.null();
           verifyItemDetails(itemDetails, 'Briefcase Full of Blues - CD', 'Music');
           waitForDone(done);
         });
@@ -61,7 +62,7 @@ describe('price-finder for Best Buy URIs', () => {
 
       it('should respond with a price for findItemPrice()', (done) => {
         priceFinder.findItemPrice(uri, (err, price) => {
-          expect(err).toBeNull();
+          should(err).be.null();
           verifyPrice(price);
           done();
         });
@@ -69,7 +70,7 @@ describe('price-finder for Best Buy URIs', () => {
 
       it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
         priceFinder.findItemDetails(uri, (err, itemDetails) => {
-          expect(err).toBeNull();
+          should(err).be.null();
           verifyItemDetails(itemDetails, 'Ferris Bueller\'s Day Off (DVD) (Eng/Fre) 1986', 'Movies & TV');
           done();
         });
@@ -83,7 +84,7 @@ describe('price-finder for Best Buy URIs', () => {
 
       it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
         priceFinder.findItemDetails(uri, (err, itemDetails) => {
-          expect(err).toBeNull();
+          should(err).be.null();
           verifyItemDetails(itemDetails, 'Super Mario 3D Land - Nintendo 3DS', 'Video Games');
           done();
         });

--- a/test/e2e/crutchfield-uris-test.js
+++ b/test/e2e/crutchfield-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -14,7 +15,7 @@ describe('price-finder for Crutchfield Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -22,7 +23,7 @@ describe('price-finder for Crutchfield Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Samsung BD-J5700', 'Television & Video');
         done();
       });
@@ -36,7 +37,7 @@ describe('price-finder for Crutchfield Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -44,7 +45,7 @@ describe('price-finder for Crutchfield Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Marantz NR1504', 'Home Audio');
         done();
       });

--- a/test/e2e/ebags-uris-test.js
+++ b/test/e2e/ebags-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -14,7 +15,7 @@ describe('price-finder for eBags Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -22,7 +23,7 @@ describe('price-finder for eBags Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'TLS Mother Lode Mini 21" Wheeled Duffel', 'Luggage');
         done();
       });

--- a/test/e2e/flipkart-uris-test.js
+++ b/test/e2e/flipkart-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -12,7 +13,7 @@ describe('price-finder for Flipkart Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -20,7 +21,7 @@ describe('price-finder for Flipkart Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Apple iPhone 6', 'Other');
         done();
       });

--- a/test/e2e/gamestop-uris-test.js
+++ b/test/e2e/gamestop-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -14,7 +15,7 @@ describe('price-finder for GameStop Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -22,7 +23,7 @@ describe('price-finder for GameStop Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Mario Kart 8', 'Video Games');
         done();
       });

--- a/test/e2e/gog-uris-test.js
+++ b/test/e2e/gog-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -13,7 +14,7 @@ describe('price-finder for Gog Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -21,7 +22,7 @@ describe('price-finder for Gog Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'DON\'T STARVE', 'Video Games');
         done();
       });

--- a/test/e2e/google-play-uris-test.js
+++ b/test/e2e/google-play-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -14,7 +15,7 @@ describe('price-finder for Google Play URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -22,7 +23,7 @@ describe('price-finder for Google Play URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'AMOK', 'Digital Music');
         done();
       });
@@ -36,7 +37,7 @@ describe('price-finder for Google Play URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -44,7 +45,7 @@ describe('price-finder for Google Play URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Big', 'Movies & TV');
         done();
       });
@@ -58,7 +59,7 @@ describe('price-finder for Google Play URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -66,7 +67,7 @@ describe('price-finder for Google Play URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Plants vs. Zombies™', 'Mobile Apps');
         done();
       });

--- a/test/e2e/greenman-gaming-uris-test.js
+++ b/test/e2e/greenman-gaming-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -12,7 +13,7 @@ describe('price-finder for GreenmanGaming Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -20,7 +21,7 @@ describe('price-finder for GreenmanGaming Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Homefront: The Revolution (NA)', 'Video Games');
         done();
       });

--- a/test/e2e/infibeam-uris-test.js
+++ b/test/e2e/infibeam-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -12,7 +13,7 @@ describe('price-finder for Infibeam Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -20,7 +21,7 @@ describe('price-finder for Infibeam Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Sansui SJX22FB Full HD LED TV', 'Electronics');
         done();
       });

--- a/test/e2e/newegg-uris-test.js
+++ b/test/e2e/newegg-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -18,7 +19,7 @@ describe('price-finder for NewEgg URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -26,7 +27,7 @@ describe('price-finder for NewEgg URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Axon - ZTE Unlocked Smartphone, 5.5" ' +
           'Qualcomm Snapdragon 801, 2GB RAM, 4G LTE, Quick-charge 2.0 - 32GB Gold',
           'Mobile Phones');

--- a/test/e2e/nintendo-uris-test.js
+++ b/test/e2e/nintendo-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -14,7 +15,7 @@ describe('price-finder for Nintendo URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -22,7 +23,7 @@ describe('price-finder for Nintendo URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'New Super Mario Bros. U', 'Video Games');
         done();
       });
@@ -36,7 +37,7 @@ describe('price-finder for Nintendo URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -44,7 +45,7 @@ describe('price-finder for Nintendo URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Super Smash Bros.', 'Video Games');
         done();
       });

--- a/test/e2e/priceminister-uris-test.js
+++ b/test/e2e/priceminister-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -14,7 +15,7 @@ describe('price-finder for PriceMinister Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -22,7 +23,7 @@ describe('price-finder for PriceMinister Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Call of duty black ops iii', 'Video Games');
         done();
       });

--- a/test/e2e/snapdeal-uris-test.js
+++ b/test/e2e/snapdeal-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -12,7 +13,7 @@ describe('price-finder for Snapdeal Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -20,7 +21,7 @@ describe('price-finder for Snapdeal Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'iPhone 6s 16GB', 'Mobile Phones');
         done();
       });

--- a/test/e2e/sony-entertainment-network-store-uris-test.js
+++ b/test/e2e/sony-entertainment-network-store-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -14,7 +15,7 @@ describe('price-finder for Sony Entertainment Network Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -22,7 +23,7 @@ describe('price-finder for Sony Entertainment Network Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'PixelJunk™ Monsters', 'Video Games');
         done();
       });

--- a/test/e2e/steam-uris-test.js
+++ b/test/e2e/steam-uris-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const testHelper = require('./test-helper');
 
 const priceFinder = testHelper.priceFinder;
@@ -13,7 +14,7 @@ describe('price-finder for Steam Store URIs', () => {
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyPrice(price);
         done();
       });
@@ -21,7 +22,7 @@ describe('price-finder for Steam Store URIs', () => {
 
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        expect(err).toBeNull();
+        should(err).be.null();
         verifyItemDetails(itemDetails, 'Don\'t Starve', 'Video Games');
         done();
       });

--- a/test/e2e/test-helper.js
+++ b/test/e2e/test-helper.js
@@ -1,15 +1,10 @@
 'use strict';
 
-// set the timeout for each test to 60 seconds (crazy! but necessary it seems)
-const TEST_TIMEOUT = 60000;
+const should = require('should');
 
 // set the price-finder retry sleep time to 5 seconds
 // (in an attempt to avoid spamming these sites should we need to retry)
 const RETRY_SLEEP_TIME = 5000;
-
-// populate the test timeout to all available jasmime listeners
-jasmine.getEnv().defaultTimeoutInterval = TEST_TIMEOUT;
-jasmine.DEFAULT_TIMEOUT_INTERVAL = TEST_TIMEOUT;
 
 // create a single instance of price-finder that will be used by e2e tests
 const PriceFinder = require('../../lib/price-finder');
@@ -18,23 +13,23 @@ exports.priceFinder = new PriceFinder({
 });
 
 exports.verifyPrice = function verifyPrice(price) {
-  expect(price).toBeDefined();
+  should.exist(price);
 
   // we can't guarantee the price, so just make sure it's a number
   // that's more than -1
-  expect(price).toBeGreaterThan(-1);
+  should(price).be.above(-1);
 };
 
 function verifyName(actualName, expectedName) {
-  expect(actualName).toEqual(expectedName);
+  should(actualName).equal(expectedName);
 }
 
 function verifyCategory(actualCategory, expectedCategory) {
-  expect(actualCategory).toEqual(expectedCategory);
+  should(actualCategory).equal(expectedCategory);
 }
 
 exports.verifyItemDetails = function verifyItemDetails(itemDetails, name, category) {
-  expect(itemDetails).toBeDefined();
+  should.exist(itemDetails);
 
   if (itemDetails) {
     exports.verifyPrice(itemDetails.price);

--- a/test/unit/site-manager-test.js
+++ b/test/unit/site-manager-test.js
@@ -1,23 +1,25 @@
 'use strict';
 
+const should = require('should');
 const siteManager = require('../../lib/site-manager');
 
 const KNOWN_SITE = 'www.amazon.com/123/product';
+const BAD_SITE = 'www.bad_uri.bad';
 
 describe('The Site Manager', () => {
   it('should exist', () => {
-    expect(siteManager).toBeDefined();
+    should.exist(siteManager);
   });
 
   it('should throw an exception for an unknown uri', () => {
-    expect(() => {
-      siteManager.loadSite('www.bad_uri.bad');
-    }).toThrow();
+    should.throws(() => {
+      siteManager.loadSite(BAD_SITE);
+    });
   });
 
   it('should return the site for a known URI', () => {
     const site = siteManager.loadSite(KNOWN_SITE);
-    expect(site).toBeDefined();
+    should.exist(site);
   });
 
   describe('loading a specific site', () => {
@@ -28,11 +30,11 @@ describe('The Site Manager', () => {
     });
 
     it('should exist', () => {
-      expect(site).toBeDefined();
+      should.exist(site);
     });
 
     it('should have site operations available', () => {
-      expect(site.isJSON).toBeDefined();
+      should.exist(site.isJSON);
     });
   });
 });

--- a/test/unit/site-utils-test.js
+++ b/test/unit/site-utils-test.js
@@ -2,25 +2,26 @@
 
 const siteUtils = require('../../lib/site-utils');
 const cheerio = require('cheerio');
+const should = require('should');
 
 describe('The Site Utils', () => {
   it('should exist', () => {
-    expect(siteUtils).toBeDefined();
+    should.exist(siteUtils);
   });
 
   it('should have categories', () => {
-    expect(siteUtils.categories).toBeDefined();
+    should.exist(siteUtils.categories);
   });
 
   it('should be at least 1 category in categories', () => {
     const keys = Object.keys(siteUtils.categories);
-    expect(keys.length).toBeGreaterThan(0);
+    should(keys.length).be.above(0);
   });
 
   it('should have some known categories', () => {
-    expect(siteUtils.categories.MUSIC).toEqual('Music');
-    expect(siteUtils.categories.VIDEO_GAMES).toEqual('Video Games');
-    expect(siteUtils.categories.BOOKS).toEqual('Books');
+    should(siteUtils.categories.MUSIC).equal('Music');
+    should(siteUtils.categories.VIDEO_GAMES).equal('Video Games');
+    should(siteUtils.categories.BOOKS).equal('Books');
   });
 
   describe('findContentOnPage() with a populated page', () => {
@@ -48,7 +49,7 @@ describe('The Site Utils', () => {
 
       const price = siteUtils.findContentOnPage($, selectors);
 
-      expect(price).toEqual('$9.99');
+      should(price).equal('$9.99');
     });
 
     it('should return the price given the multiple matches for selector', () => {
@@ -58,7 +59,7 @@ describe('The Site Utils', () => {
 
       const price = siteUtils.findContentOnPage($, selectors);
 
-      expect(price).toEqual('$1.99');
+      should(price).equal('$1.99');
     });
 
     it('should return the price given a first() element', () => {
@@ -70,7 +71,7 @@ describe('The Site Utils', () => {
 
       const price = siteUtils.findContentOnPage(jQuery, selectors);
 
-      expect(price).toEqual('$12.34');
+      should(price).equal('$12.34');
     });
 
     it('should return null given incorrect selector', () => {
@@ -80,49 +81,49 @@ describe('The Site Utils', () => {
 
       const price = siteUtils.findContentOnPage($, selectors);
 
-      expect(price).toEqual(null);
+      should(price).be.null();
     });
   });
 
   describe('processPrice()', () => {
     it('should process $ price correctly', () => {
-      expect(siteUtils.processPrice('$3.99')).toEqual(3.99);
+      should(siteUtils.processPrice('$3.99')).equal(3.99);
     });
 
     it('should process EUR price correctly', () => {
-      expect(siteUtils.processPrice('EUR 79,40')).toEqual(79.40);
+      should(siteUtils.processPrice('EUR 79,40')).equal(79.40);
     });
 
     it('should process eur price correctly', () => {
-      expect(siteUtils.processPrice('eur 79,40')).toEqual(79.40);
+      should(siteUtils.processPrice('eur 79,40')).equal(79.40);
     });
 
     it('should process Euros price correctly', () => {
-      expect(siteUtils.processPrice('Euros 79,40')).toEqual(79.40);
+      should(siteUtils.processPrice('Euros 79,40')).equal(79.40);
     });
 
     it('should process € price correctly', () => {
-      expect(siteUtils.processPrice('€ 79,40')).toEqual(79.40);
+      should(siteUtils.processPrice('€ 79,40')).equal(79.40);
     });
 
     it('should process YEN_TEXT price correctly', () => {
-      expect(siteUtils.processPrice('7,940 円')).toEqual(7940);
+      should(siteUtils.processPrice('7,940 円')).equal(7940);
     });
 
     it('should process YEN_SYMBOL price correctly', () => {
-      expect(siteUtils.processPrice('￥ 7,940')).toEqual(7940);
+      should(siteUtils.processPrice('￥ 7,940')).equal(7940);
     });
 
     it('should process £ price correctly', () => {
-      expect(siteUtils.processPrice('£3.99')).toEqual(3.99);
+      should(siteUtils.processPrice('£3.99')).equal(3.99);
     });
 
     it('should process INR price correctly', () => {
-      expect(siteUtils.processPrice('R 9,444')).toEqual(9444);
+      should(siteUtils.processPrice('R 9,444')).equal(9444);
     });
 
     it('should process an unknown price correctly', () => {
-      expect(siteUtils.processPrice('hey, without symbol?')).toEqual(-1);
+      should(siteUtils.processPrice('hey, without symbol?')).equal(-1);
     });
   });
 });

--- a/test/unit/sites/amazon-test.js
+++ b/test/unit/sites/amazon-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const AmazonSite = require('../../../lib/sites/amazon');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const AmazonSite = require('../../../lib/sites/amazon');
 
 const VALID_URI = 'http://www.amazon.com/123/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The Amazon Site', () => {
   it('should exist', () => {
-    expect(AmazonSite).toBeDefined();
+    should.exist(AmazonSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(AmazonSite.isSite(VALID_URI)).toBeTruthy();
+      should(AmazonSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(AmazonSite.isSite(INVALID_URI)).toBeFalsy();
+      should(AmazonSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new AmazonSite with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new AmazonSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new Amazon Site', () => {
@@ -38,15 +39,15 @@ describe('The Amazon Site', () => {
     });
 
     it('should exist', () => {
-      expect(amazon).toBeDefined();
+      should.exist(amazon);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(amazon.getURIForPageData()).toEqual(VALID_URI);
+      should(amazon.getURIForPageData()).equal(VALID_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(amazon.isJSON()).toBeFalsy();
+      should(amazon.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -69,38 +70,38 @@ describe('The Amazon Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = amazon.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = amazon.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should return the category when displayed on the page', () => {
         const categoryFound = amazon.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return OTHER when the category is not setup', () => {
         $ = cheerio.load('<div id="nav-subnav" data-category="something-new">stuff</div>');
         const categoryFound = amazon.findCategoryOnPage($);
-        expect(categoryFound).toEqual(siteUtils.categories.OTHER);
+        should(categoryFound).equal(siteUtils.categories.OTHER);
       });
 
       it('should return null when the category does not exist', () => {
         const categoryFound = amazon.findCategoryOnPage(bad$);
-        expect(categoryFound).toEqual(null);
+        should(categoryFound).be.null();
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = amazon.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = amazon.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/best-buy-test.js
+++ b/test/unit/sites/best-buy-test.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const BestBuySite = require('../../../lib/sites/best-buy');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const BestBuySite = require('../../../lib/sites/best-buy');
 
 const VALID_URI = 'http://www.bestbuy.com/site/product?skuId=123';
 const INVALID_URI = 'http://www.bad.com/123/product';
@@ -10,25 +11,25 @@ const TRANSLATED_URI = 'https://api.remix.bestbuy.com/v1/products/123.json?show=
 
 describe('The Best Buy Site', () => {
   it('should exist', () => {
-    expect(BestBuySite).toBeDefined();
+    should.exist(BestBuySite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(BestBuySite.isSite(VALID_URI)).toBeTruthy();
+      should(BestBuySite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(BestBuySite.isSite(INVALID_URI)).toBeFalsy();
+      should(BestBuySite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new BestBuySite with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new BestBuySite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('without an API key in the environment', () => {
@@ -46,23 +47,23 @@ describe('The Best Buy Site', () => {
     });
 
     it('should not throw an exception trying to create a new BestBuySite', () => {
-      expect(() => {
+      should.doesNotThrow(() => {
         /* eslint-disable no-new */
         new BestBuySite(VALID_URI);
         /* eslint-enable no-new */
-      }).not.toThrow();
+      });
     });
 
     it('should exist', () => {
-      expect(site).toBeDefined();
+      should.exist(site);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(site.getURIForPageData()).toEqual(VALID_URI);
+      should(site.getURIForPageData()).equal(VALID_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(site.isJSON()).toBeFalsy();
+      should(site.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -90,27 +91,27 @@ describe('The Best Buy Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = site.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = site.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should always return the category', () => {
         const categoryFound = site.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = site.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = site.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });
@@ -129,23 +130,23 @@ describe('The Best Buy Site', () => {
     });
 
     it('should not throw an exception trying to create a new BestBuySite', () => {
-      expect(() => {
+      should.doesNotThrow(() => {
         /* eslint-disable no-new */
         new BestBuySite(VALID_URI, {});
         /* eslint-enable no-new */
-      }).not.toThrow();
+      });
     });
 
     it('should exist', () => {
-      expect(bestBuy).toBeDefined();
+      should.exist(bestBuy);
     });
 
     it('should return the translated URI for getURIForPageData()', () => {
-      expect(bestBuy.getURIForPageData()).toEqual(TRANSLATED_URI);
+      should(bestBuy.getURIForPageData()).equal(TRANSLATED_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(bestBuy.isJSON()).toBeTruthy();
+      should(bestBuy.isJSON()).be.true();
     });
 
     describe('with a populated page', () => {
@@ -170,38 +171,38 @@ describe('The Best Buy Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = bestBuy.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = bestBuy.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should return the category when displayed on the page', () => {
         const categoryFound = bestBuy.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return OTHER when the category is not setup', () => {
         $ = require('./mock-data/bestbuy-other_category.json');
         const categoryFound = bestBuy.findCategoryOnPage($);
-        expect(categoryFound).toEqual(siteUtils.categories.OTHER);
+        should(categoryFound).equal(siteUtils.categories.OTHER);
       });
 
       it('should return null when the category does not exist', () => {
         const categoryFound = bestBuy.findCategoryOnPage(bad$);
-        expect(categoryFound).toEqual(null);
+        should(categoryFound).be.null();
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = bestBuy.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = bestBuy.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/crutchfield-test.js
+++ b/test/unit/sites/crutchfield-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const CrutchfieldSite = require('../../../lib/sites/crutchfield');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const CrutchfieldSite = require('../../../lib/sites/crutchfield');
 
 const VALID_URI = 'http://www.crutchfield.com/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The Crutchfield Site', () => {
   it('should exist', () => {
-    expect(CrutchfieldSite).toBeDefined();
+    should.exist(CrutchfieldSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(CrutchfieldSite.isSite(VALID_URI)).toBeTruthy();
+      should(CrutchfieldSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(CrutchfieldSite.isSite(INVALID_URI)).toBeFalsy();
+      should(CrutchfieldSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new CrutchfieldSite with an bad uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new CrutchfieldSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new Crutchfield Site', () => {
@@ -38,15 +39,15 @@ describe('The Crutchfield Site', () => {
     });
 
     it('should exist', () => {
-      expect(crutchfield).toBeDefined();
+      should.exist(crutchfield);
     });
 
     it('should return false for isJSON()', () => {
-      expect(crutchfield.isJSON()).toBeFalsy();
+      should(crutchfield.isJSON()).be.false();
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(crutchfield.getURIForPageData()).toEqual(VALID_URI);
+      should(crutchfield.getURIForPageData()).equal(VALID_URI);
     });
 
     describe('with a populated page', () => {
@@ -79,17 +80,17 @@ describe('The Crutchfield Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = crutchfield.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = crutchfield.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should return the category when displayed on the page', () => {
         const categoryFound = crutchfield.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return OTHER when the category is not setup', () => {
@@ -100,22 +101,22 @@ describe('The Crutchfield Site', () => {
           '</div>'
         );
         const categoryFound = crutchfield.findCategoryOnPage($);
-        expect(categoryFound).toEqual(siteUtils.categories.OTHER);
+        should(categoryFound).equal(siteUtils.categories.OTHER);
       });
 
       it('should return null when the category does not exist', () => {
         const categoryFound = crutchfield.findCategoryOnPage(bad$);
-        expect(categoryFound).toEqual(null);
+        should(categoryFound).be.null();
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = crutchfield.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = crutchfield.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/ebags-test.js
+++ b/test/unit/sites/ebags-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const EBagsSite = require('../../../lib/sites/ebags');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const EBagsSite = require('../../../lib/sites/ebags');
 
 const VALID_URI = 'http://www.ebags.com/123/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The eBags Site', () => {
   it('should exist', () => {
-    expect(EBagsSite).toBeDefined();
+    should.exist(EBagsSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(EBagsSite.isSite(VALID_URI)).toBeTruthy();
+      should(EBagsSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(EBagsSite.isSite(INVALID_URI)).toBeFalsy();
+      should(EBagsSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new EBagsSite with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new EBagsSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new eBags Site', () => {
@@ -38,15 +39,15 @@ describe('The eBags Site', () => {
     });
 
     it('should exist', () => {
-      expect(ebags).toBeDefined();
+      should.exist(ebags);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(ebags.getURIForPageData()).toEqual(VALID_URI);
+      should(ebags.getURIForPageData()).equal(VALID_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(ebags.isJSON()).toBeFalsy();
+      should(ebags.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -72,27 +73,27 @@ describe('The eBags Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = ebags.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = ebags.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should always return the category', () => {
         const categoryFound = ebags.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = ebags.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = ebags.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/flipkart-test.js
+++ b/test/unit/sites/flipkart-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const FlipkartSite = require('../../../lib/sites/flipkart');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const FlipkartSite = require('../../../lib/sites/flipkart');
 
 const VALID_URI = 'http://www.flipkart.com/123/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The Flipkart Site', () => {
   it('should exist', () => {
-    expect(FlipkartSite).toBeDefined();
+    should.exist(FlipkartSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(FlipkartSite.isSite(VALID_URI)).toBeTruthy();
+      should(FlipkartSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(FlipkartSite.isSite(INVALID_URI)).toBeFalsy();
+      should(FlipkartSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new site with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new FlipkartSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new Flipkart Site', () => {
@@ -38,15 +39,15 @@ describe('The Flipkart Site', () => {
     });
 
     it('should exist', () => {
-      expect(site).toBeDefined();
+      should.exist(site);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(site.getURIForPageData()).toEqual(VALID_URI);
+      should(site.getURIForPageData()).equal(VALID_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(site.isJSON()).toBeFalsy();
+      should(site.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -71,27 +72,27 @@ describe('The Flipkart Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = site.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = site.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should always return the category', () => {
         const categoryFound = site.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = site.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = site.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/gamestop-test.js
+++ b/test/unit/sites/gamestop-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const GameStopSite = require('../../../lib/sites/gamestop');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const GameStopSite = require('../../../lib/sites/gamestop');
 
 const VALID_URI = 'http://www.gamestop.com/games/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The GameStop Site', () => {
   it('should exist', () => {
-    expect(GameStopSite).toBeDefined();
+    should.exist(GameStopSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(GameStopSite.isSite(VALID_URI)).toBeTruthy();
+      should(GameStopSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(GameStopSite.isSite(INVALID_URI)).toBeFalsy();
+      should(GameStopSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new GameStopSite with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new GameStopSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new GameStop Site', () => {
@@ -38,15 +39,15 @@ describe('The GameStop Site', () => {
     });
 
     it('should exist', () => {
-      expect(gamestop).toBeDefined();
+      should.exist(gamestop);
     });
 
     it('should return false for isJSON()', () => {
-      expect(gamestop.isJSON()).toBeFalsy();
+      should(gamestop.isJSON()).be.false();
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(gamestop.getURIForPageData()).toEqual(VALID_URI);
+      should(gamestop.getURIForPageData()).equal(VALID_URI);
     });
 
     describe('with a populated page', () => {
@@ -77,27 +78,27 @@ describe('The GameStop Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = gamestop.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = gamestop.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should always return the video games category', () => {
         const categoryFound = gamestop.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = gamestop.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = gamestop.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/gog-test.js
+++ b/test/unit/sites/gog-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const GogSite = require('../../../lib/sites/gog');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const GogSite = require('../../../lib/sites/gog');
 
 const VALID_URI = 'http://www.gog.com/123/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The Gog Site', () => {
   it('should exist', () => {
-    expect(GogSite).toBeDefined();
+    should.exist(GogSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(GogSite.isSite(VALID_URI)).toBeTruthy();
+      should(GogSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(GogSite.isSite(INVALID_URI)).toBeFalsy();
+      should(GogSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new site with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new GogSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new Gog Site', () => {
@@ -38,15 +39,15 @@ describe('The Gog Site', () => {
     });
 
     it('should exist', () => {
-      expect(site).toBeDefined();
+      should.exist(site);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(site.getURIForPageData()).toEqual(VALID_URI);
+      should(site.getURIForPageData()).equal(VALID_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(site.isJSON()).toBeFalsy();
+      should(site.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -70,27 +71,27 @@ describe('The Gog Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = site.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = site.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should always return the category', () => {
         const categoryFound = site.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = site.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = site.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/google-play-test.js
+++ b/test/unit/sites/google-play-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const GooglePlaySite = require('../../../lib/sites/google-play');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const GooglePlaySite = require('../../../lib/sites/google-play');
 
 const VALID_URI = 'https://play.google.com/store/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The GooglePlay Site', () => {
   it('should exist', () => {
-    expect(GooglePlaySite).toBeDefined();
+    should.exist(GooglePlaySite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(GooglePlaySite.isSite(VALID_URI)).toBeTruthy();
+      should(GooglePlaySite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(GooglePlaySite.isSite(INVALID_URI)).toBeFalsy();
+      should(GooglePlaySite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new site with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new GooglePlaySite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new GooglePlay Site', () => {
@@ -38,15 +39,15 @@ describe('The GooglePlay Site', () => {
     });
 
     it('should exist', () => {
-      expect(googlePlay).toBeDefined();
+      should.exist(googlePlay);
     });
 
     it('should return false for isJSON()', () => {
-      expect(googlePlay.isJSON()).toBeFalsy();
+      should(googlePlay.isJSON()).be.false();
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(googlePlay.getURIForPageData()).toEqual(VALID_URI);
+      should(googlePlay.getURIForPageData()).equal(VALID_URI);
     });
 
     describe('with a populated page', () => {
@@ -71,38 +72,38 @@ describe('The GooglePlay Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = googlePlay.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = googlePlay.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should return the category when displayed on the page', () => {
         const categoryFound = googlePlay.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return OTHER when the category is not setup', () => {
         $ = cheerio.load('<title>Big - Something Else on Google Play</title>');
         const categoryFound = googlePlay.findCategoryOnPage($);
-        expect(categoryFound).toEqual(siteUtils.categories.OTHER);
+        should(categoryFound).equal(siteUtils.categories.OTHER);
       });
 
       it('should return null when the category does not exist', () => {
         const categoryFound = googlePlay.findCategoryOnPage(bad$);
-        expect(categoryFound).toEqual(null);
+        should(categoryFound).be.null();
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = googlePlay.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = googlePlay.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/greenman-gaming-test.js
+++ b/test/unit/sites/greenman-gaming-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const GreenmanGamingSite = require('../../../lib/sites/greenman-gaming');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const GreenmanGamingSite = require('../../../lib/sites/greenman-gaming');
 
 const VALID_URI = 'http://greenmangaming.com/123/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The GreenmanGaming Site', () => {
   it('should exist', () => {
-    expect(GreenmanGamingSite).toBeDefined();
+    should.exist(GreenmanGamingSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(GreenmanGamingSite.isSite(VALID_URI)).toBeTruthy();
+      should(GreenmanGamingSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(GreenmanGamingSite.isSite(INVALID_URI)).toBeFalsy();
+      should(GreenmanGamingSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new site with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new GreenmanGamingSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new GreenmanGaming Site', () => {
@@ -38,15 +39,15 @@ describe('The GreenmanGaming Site', () => {
     });
 
     it('should exist', () => {
-      expect(site).toBeDefined();
+      should.exist(site);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(site.getURIForPageData()).toEqual(VALID_URI);
+      should(site.getURIForPageData()).equal(VALID_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(site.isJSON()).toBeFalsy();
+      should(site.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -61,37 +62,41 @@ describe('The GreenmanGaming Site', () => {
         category = siteUtils.categories.VIDEO_GAMES;
         name = 'Homefront: The Revolution';
 
-        $ = cheerio.load(`<strong class="curPrice">₹4199.30</strong>
+        $ = cheerio.load(`
           <h1 itemprop="name">Homefront: The Revolution</h1>
-          <script>var utag_data = {"currency_code": "INR",
-          "request_path": "/s/in/en/pc/games/action/far-cry-primal/",
-          "product_price_readable": "4199.30"};</script>`);
+          <script>
+            var utag_data = {
+              "currency_code": "INR",
+              "product_price_readable": "4199.30"
+            };
+          </script>
+        `);
         bad$ = cheerio.load('<h1>Nothin here</h1>');
       });
 
       it('should return the price when displayed on the page', () => {
         const priceFound = site.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = site.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should always return the category', () => {
         const categoryFound = site.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = site.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = site.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/infibeam-test.js
+++ b/test/unit/sites/infibeam-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const InfibeamSite = require('../../../lib/sites/infibeam');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const InfibeamSite = require('../../../lib/sites/infibeam');
 
 const VALID_URI = 'http://www.infibeam.com/Home_Entertainment/sansui-sjx22fb-full-hd-led-tv/P-hoen-68091831042-cat-z.html#variantId=P-hoen-60492354794';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The Infibeam Site', () => {
   it('should exist', () => {
-    expect(InfibeamSite).toBeDefined();
+    should.exist(InfibeamSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(InfibeamSite.isSite(VALID_URI)).toBeTruthy();
+      should(InfibeamSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(InfibeamSite.isSite(INVALID_URI)).toBeFalsy();
+      should(InfibeamSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new site with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new InfibeamSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new Infibeam Site', () => {
@@ -38,15 +39,15 @@ describe('The Infibeam Site', () => {
     });
 
     it('should exist', () => {
-      expect(site).toBeDefined();
+      should.exist(site);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(site.getURIForPageData()).toEqual(VALID_URI);
+      should(site.getURIForPageData()).equal(VALID_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(site.isJSON()).toBeFalsy();
+      should(site.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -73,27 +74,27 @@ describe('The Infibeam Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = site.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = site.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should always return the category', () => {
         const categoryFound = site.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = site.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = site.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/newegg-test.js
+++ b/test/unit/sites/newegg-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const NewEggSite = require('../../../lib/sites/newegg');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const NewEggSite = require('../../../lib/sites/newegg');
 
 const VALID_URI = 'http://www.newegg.com/Product/Product.aspx?Item=N82E16875705040';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The NewEgg Site', () => {
   it('should exist', () => {
-    expect(NewEggSite).toBeDefined();
+    should.exist(NewEggSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(NewEggSite.isSite(VALID_URI)).toBeTruthy();
+      should(NewEggSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(NewEggSite.isSite(INVALID_URI)).toBeFalsy();
+      should(NewEggSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new NewEggSite with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new NewEggSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new NewEgg Site', () => {
@@ -38,15 +39,15 @@ describe('The NewEgg Site', () => {
     });
 
     it('should exist', () => {
-      expect(newegg).toBeDefined();
+      should.exist(newegg);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(newegg.getURIForPageData()).toEqual(VALID_URI);
+      should(newegg.getURIForPageData()).equal(VALID_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(newegg.isJSON()).toBeFalsy();
+      should(newegg.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -76,12 +77,12 @@ describe('The NewEgg Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = newegg.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = newegg.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should return the category when displayed on the page', () => {
@@ -100,7 +101,7 @@ describe('The NewEgg Site', () => {
           <dd style="font-weight:bold;font-style:italic;">Item#:&nbsp;<em>N82E16875705040</em>
           </dd></dl></div>`);
         const categoryFound = newegg.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return OTHER when the category is not setup', () => {
@@ -119,22 +120,22 @@ describe('The NewEgg Site', () => {
           <dd style="font-weight:bold;font-style:italic;">Item#:&nbsp;<em>N82E16875705040</em>
           </dd></dl></div>`);
         const categoryFound = newegg.findCategoryOnPage($);
-        expect(categoryFound).toEqual(siteUtils.categories.OTHER);
+        should(categoryFound).equal(siteUtils.categories.OTHER);
       });
 
       it('should return null when the category does not exist', () => {
         const categoryFound = newegg.findCategoryOnPage(bad$);
-        expect(categoryFound).toEqual(null);
+        should(categoryFound).be.null();
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = newegg.findNameOnPage($);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = newegg.findNameOnPage(bad$);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/nintendo-test.js
+++ b/test/unit/sites/nintendo-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const NintendoSite = require('../../../lib/sites/nintendo');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const NintendoSite = require('../../../lib/sites/nintendo');
 
 const VALID_URI = 'http://www.nintendo.com/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The Nintendo Site', () => {
   it('should exist', () => {
-    expect(NintendoSite).toBeDefined();
+    should.exist(NintendoSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(NintendoSite.isSite(VALID_URI)).toBeTruthy();
+      should(NintendoSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(NintendoSite.isSite(INVALID_URI)).toBeFalsy();
+      should(NintendoSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new NintendoSite with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new NintendoSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new Nintento Site', () => {
@@ -38,15 +39,15 @@ describe('The Nintendo Site', () => {
     });
 
     it('should exist', () => {
-      expect(nintendo).toBeDefined();
+      should.exist(nintendo);
     });
 
     it('should return false for isJSON()', () => {
-      expect(nintendo.isJSON()).toBeFalsy();
+      should(nintendo.isJSON()).be.false();
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(nintendo.getURIForPageData()).toEqual(VALID_URI);
+      should(nintendo.getURIForPageData()).equal(VALID_URI);
     });
 
     describe('with a populated page', () => {
@@ -72,27 +73,27 @@ describe('The Nintendo Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = nintendo.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = nintendo.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should return the category', () => {
         const categoryFound = nintendo.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = nintendo.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = nintendo.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/priceminister-test.js
+++ b/test/unit/sites/priceminister-test.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const PriceMinisterSite = require('../../../lib/sites/priceminister');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const PriceMinisterSite = require('../../../lib/sites/priceminister');
 
 const VALID_URI = 'http://www.priceminister.com/mfp/123/my-video-game#pid=456';
 const TRANSLATED_URL = 'http://www.priceminister.com/mfp?cid=123&urlname=my-video-game&pid=456&action=advlstmeta';
@@ -10,25 +11,25 @@ const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The PriceMinister Site', () => {
   it('should exist', () => {
-    expect(PriceMinisterSite).toBeDefined();
+    should.exist(PriceMinisterSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(PriceMinisterSite.isSite(VALID_URI)).toBeTruthy();
+      should(PriceMinisterSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(PriceMinisterSite.isSite(INVALID_URI)).toBeFalsy();
+      should(PriceMinisterSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new site with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new PriceMinisterSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new PriceMinister Site', () => {
@@ -39,15 +40,15 @@ describe('The PriceMinister Site', () => {
     });
 
     it('should exist', () => {
-      expect(priceminister).toBeDefined();
+      should.exist(priceminister);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(priceminister.getURIForPageData()).toEqual(TRANSLATED_URL);
+      should(priceminister.getURIForPageData()).equal(TRANSLATED_URL);
     });
 
     it('should return false for isJSON()', () => {
-      expect(priceminister.isJSON()).toBeFalsy();
+      should(priceminister.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -76,27 +77,27 @@ describe('The PriceMinister Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = priceminister.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = priceminister.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should always return the VIDEO_GAMES category', () => {
         const categoryFound = priceminister.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = priceminister.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
-      it('should not return null when the name is not displayed on the page', () => {
+      it('should return the name without displayed on page, from uri', () => {
         const nameFound = priceminister.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
     });
   });

--- a/test/unit/sites/snapdeal-test.js
+++ b/test/unit/sites/snapdeal-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const SnapdealSite = require('../../../lib/sites/snapdeal');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const SnapdealSite = require('../../../lib/sites/snapdeal');
 
 const VALID_URI = 'http://www.snapdeal.com/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The Snapdeal Site', () => {
   it('should exist', () => {
-    expect(SnapdealSite).toBeDefined();
+    should.exist(SnapdealSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(SnapdealSite.isSite(VALID_URI)).toBeTruthy();
+      should(SnapdealSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(SnapdealSite.isSite(INVALID_URI)).toBeFalsy();
+      should(SnapdealSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new site with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new SnapdealSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new Snapdeal Site', () => {
@@ -38,15 +39,15 @@ describe('The Snapdeal Site', () => {
     });
 
     it('should exist', () => {
-      expect(site).toBeDefined();
+      should.exist(site);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(site.getURIForPageData()).toEqual(VALID_URI);
+      should(site.getURIForPageData()).equal(VALID_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(site.isJSON()).toBeFalsy();
+      should(site.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -71,27 +72,27 @@ describe('The Snapdeal Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = site.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = site.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should always return the category', () => {
         const categoryFound = site.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = site.findNameOnPage($);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = site.findNameOnPage(bad$);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/sony-entertainment-network-store-test.js
+++ b/test/unit/sites/sony-entertainment-network-store-test.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const SonyENSSite = require('../../../lib/sites/sony-entertainment-network-store');
+const should = require('should');
 const siteUtils = require('../../../lib/site-utils');
+const SonyENSSite = require('../../../lib/sites/sony-entertainment-network-store');
 
 const VALID_URI = 'https://store.sonyentertainmentnetwork.com/#!/en-us/games/my-game/cid=123ABC';
 const VALID_URI_2 = 'https://store.playstation.com/#!/en-us/games/my-game/cid=123ABC';
@@ -10,29 +11,29 @@ const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The Sony Entertainment Network Store Site', () => {
   it('should exist', () => {
-    expect(SonyENSSite).toBeDefined();
+    should.exist(SonyENSSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(SonyENSSite.isSite(VALID_URI)).toBeTruthy();
+      should(SonyENSSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return true for a correct (alternate) site', () => {
-      expect(SonyENSSite.isSite(VALID_URI_2)).toBeTruthy();
+      should(SonyENSSite.isSite(VALID_URI_2)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(SonyENSSite.isSite(INVALID_URI)).toBeFalsy();
+      should(SonyENSSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new SonyENSSite with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new SonyENSSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new Sony Entertainment Network Store Site', () => {
@@ -43,15 +44,15 @@ describe('The Sony Entertainment Network Store Site', () => {
     });
 
     it('should exist', () => {
-      expect(sony).toBeDefined();
+      should.exist(sony);
     });
 
     it('should return the API URI for getURIForPageData()', () => {
-      expect(sony.getURIForPageData()).toEqual(VALID_API_URL);
+      should(sony.getURIForPageData()).equal(VALID_API_URL);
     });
 
     it('should return true for isJSON()', () => {
-      expect(sony.isJSON()).toBeTruthy();
+      should(sony.isJSON()).be.true();
     });
 
     describe('with page data', () => {
@@ -95,43 +96,43 @@ describe('The Sony Entertainment Network Store Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = sony.findPriceOnPage(pageData);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = sony.findPriceOnPage(badPageData);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should return the playstation plus price when available', () => {
         const priceFound = sony.findPriceOnPage(pageDataWithPlaystationPlus);
-        expect(priceFound).toEqual(playstationPlusPrice);
+        should(priceFound).equal(playstationPlusPrice);
       });
 
       it('should return the category when displayed on the page', () => {
         const categoryFound = sony.findCategoryOnPage(pageData);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return OTHER when the category is not setup', () => {
         pageData.bucket = 'somethingElse';
         const categoryFound = sony.findCategoryOnPage(pageData);
-        expect(categoryFound).toEqual(siteUtils.categories.OTHER);
+        should(categoryFound).equal(siteUtils.categories.OTHER);
       });
 
       it('should return null when the category does not exist', () => {
         const categoryFound = sony.findCategoryOnPage(badPageData);
-        expect(categoryFound).toEqual(null);
+        should(categoryFound).be.null();
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = sony.findNameOnPage(pageData, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = sony.findNameOnPage(badPageData, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });

--- a/test/unit/sites/steam-test.js
+++ b/test/unit/sites/steam-test.js
@@ -1,33 +1,34 @@
 'use strict';
 
-const SteamSite = require('../../../lib/sites/steam');
+const should = require('should');
 const cheerio = require('cheerio');
 const siteUtils = require('../../../lib/site-utils');
+const SteamSite = require('../../../lib/sites/steam');
 
 const VALID_URI = 'http://store.steampowered.com/123/product';
 const INVALID_URI = 'http://www.bad.com/123/product';
 
 describe('The Steam Site', () => {
   it('should exist', () => {
-    expect(SteamSite).toBeDefined();
+    should.exist(SteamSite);
   });
 
   describe('isSite() function', () => {
     it('should return true for a correct site', () => {
-      expect(SteamSite.isSite(VALID_URI)).toBeTruthy();
+      should(SteamSite.isSite(VALID_URI)).be.true();
     });
 
     it('should return false for a bad site', () => {
-      expect(SteamSite.isSite(INVALID_URI)).toBeFalsy();
+      should(SteamSite.isSite(INVALID_URI)).be.false();
     });
   });
 
   it('should throw an exception trying to create a new site with an incorrect uri', () => {
-    expect(() => {
+    should.throws(() => {
       /* eslint-disable no-new */
       new SteamSite(INVALID_URI);
       /* eslint-enable no-new */
-    }).toThrow();
+    });
   });
 
   describe('a new Steam Site', () => {
@@ -38,15 +39,15 @@ describe('The Steam Site', () => {
     });
 
     it('should exist', () => {
-      expect(site).toBeDefined();
+      should.exist(site);
     });
 
     it('should return the same URI for getURIForPageData()', () => {
-      expect(site.getURIForPageData()).toEqual(VALID_URI);
+      should(site.getURIForPageData()).equal(VALID_URI);
     });
 
     it('should return false for isJSON()', () => {
-      expect(site.isJSON()).toBeFalsy();
+      should(site.isJSON()).be.false();
     });
 
     describe('with a populated page', () => {
@@ -72,27 +73,27 @@ describe('The Steam Site', () => {
 
       it('should return the price when displayed on the page', () => {
         const priceFound = site.findPriceOnPage($);
-        expect(priceFound).toEqual(price);
+        should(priceFound).equal(price);
       });
 
       it('should return -1 when the price is not found', () => {
         const priceFound = site.findPriceOnPage(bad$);
-        expect(priceFound).toEqual(-1);
+        should(priceFound).equal(-1);
       });
 
       it('should always return the category', () => {
         const categoryFound = site.findCategoryOnPage($);
-        expect(categoryFound).toEqual(category);
+        should(categoryFound).equal(category);
       });
 
       it('should return the name when displayed on the page', () => {
         const nameFound = site.findNameOnPage($, category);
-        expect(nameFound).toEqual(name);
+        should(nameFound).equal(name);
       });
 
       it('should return null when the name is not displayed on the page', () => {
         const nameFound = site.findNameOnPage(bad$, category);
-        expect(nameFound).toEqual(null);
+        should(nameFound).be.null();
       });
     });
   });


### PR DESCRIPTION
Switch from using Jasmine as a test framework to using Mocha (along with should).  Doing so moves us onto a test framework that has more community support, along with features that we might choose to use later (better Babel support, code coverage, etc).  In general, some of the Jasmine modules we were using (jasmine-node) were slowly loosing support.

While we’re at it, replace the use of `rewire` with `proxyquire` so we no longer have to avoid using `const` in library variable definitions (within `price-finder.js` library).

This will resolve #86 