### PR TITLE
Standardize processPrice

### DIFF
--- a/lib/site-utils.js
+++ b/lib/site-utils.js
@@ -65,9 +65,9 @@ const EURO_SYMBOL_PREFIX = '€';
 const YEN_TEXT_PREFIX = '円';
 const YEN_SYMBOL_PREFIX = '￥';
 const GBP_SYMBOL_PREFIX = '£';
-const GBP_TEXT_PREFIX = 'GBP';
-const INR_SYMBOL_PREFIX = 'R';
-const INR_TEXT_PREFIX = 'INR';
+const GBP_TEXT_PREFIX = 'gbp';
+const INR_SYMBOL_PREFIX = 'r';
+const INR_TEXT_PREFIX = 'inr';
 
 exports.processPrice = function processPrice(priceStringInput) {
   const priceString = priceStringInput.toLowerCase();
@@ -89,11 +89,11 @@ exports.processPrice = function processPrice(priceStringInput) {
     logger.log('found yen in price, converting to number...');
     price = accounting.unformat(priceString);
   } else if (_.includes(priceString, GBP_SYMBOL_PREFIX) ||
-    _.includes(priceString.toUpperCase(), GBP_TEXT_PREFIX)) {
+    _.includes(priceString, GBP_TEXT_PREFIX)) {
     logger.log('found gbp in price, converting to number...');
     price = accounting.unformat(priceString);
-  } else if (_.includes(priceString.toUpperCase(), INR_SYMBOL_PREFIX) ||
-    _.includes(priceString.toUpperCase(), INR_TEXT_PREFIX)) {
+  } else if (_.includes(priceString, INR_SYMBOL_PREFIX) ||
+    _.includes(priceString, INR_TEXT_PREFIX)) {
     logger.log('found inr in price, converting to number...');
     price = accounting.unformat(priceString);
   } else {

--- a/test/unit/site-utils-test.js
+++ b/test/unit/site-utils-test.js
@@ -90,6 +90,10 @@ describe('The Site Utils', () => {
       should(siteUtils.processPrice('$3.99')).equal(3.99);
     });
 
+    it('should process USD price correctly', () => {
+      should(siteUtils.processPrice('USD 3.99')).equal(3.99);
+    });
+
     it('should process EUR price correctly', () => {
       should(siteUtils.processPrice('EUR 79,40')).equal(79.40);
     });
@@ -118,8 +122,16 @@ describe('The Site Utils', () => {
       should(siteUtils.processPrice('£3.99')).equal(3.99);
     });
 
-    it('should process INR price correctly', () => {
+    it('should process GBP price correctly', () => {
+      should(siteUtils.processPrice('GBP 3.99')).equal(3.99);
+    });
+
+    it('should process R (INR) price correctly', () => {
       should(siteUtils.processPrice('R 9,444')).equal(9444);
+    });
+
+    it('should process INR price correctly', () => {
+      should(siteUtils.processPrice('INR 9,444')).equal(9444);
     });
 
     it('should process an unknown price correctly', () => {


### PR DESCRIPTION
Since we `toLowerCase` the price string at the start of the function, we shouldn’t need to `toUpperCase` the string in certain circumstances to make sure it’s in the correct case — we know it’s in lower case.  So remove the upper case logic.

Also add test cases for areas not tested.

This should close #81.