### PR TITLE
Update Best Buy category query

### DIFF
--- a/lib/sites/best-buy.js
+++ b/lib/sites/best-buy.js
@@ -92,8 +92,18 @@ class BestBuySite {
       rawCategory = pageData.categoryPath[1].name;
       parentCategory = pageData.categoryPath[2].name;
     } else {
-      rawCategory = $('#analytics-data').attr('data-uber-cat-name');
-      parentCategory = $('#analytics-data').attr('data-parent-cat-name');
+      // Use regex to find the category
+      const rawCategoryRegex = /track.uberCatName = "([^,;]+)";/ig;
+      const rawCategoryResults = rawCategoryRegex.exec($.html());
+      if (rawCategoryResults && rawCategoryResults.length > 1) {
+        rawCategory = rawCategoryResults[1];
+      }
+
+      const parentCategoryRegex = /track.parentCatName = "([^,;]+)";/ig;
+      const parentCategoryResults = parentCategoryRegex.exec($.html());
+      if (parentCategoryResults && parentCategoryResults.length > 1) {
+        parentCategory = parentCategoryResults[1];
+      }
     }
 
     logger.log('rawCategory: %s', rawCategory);
@@ -101,7 +111,7 @@ class BestBuySite {
 
     if (rawCategory === 'Movies & Music') {
       // need to figure out which one: Movies or Music
-      if (parentCategory.indexOf('Movies') > -1) {
+      if (parentCategory && parentCategory.indexOf('Movies') > -1) {
         category = siteUtils.categories.MOVIES_TV;
       } else {
         // assume (generic) Music if not Movies

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "grunt test",
     "test-e2e": "grunt e2e",
     "test-watch": "mocha --colors --watch --recursive test/unit",
-    "test-e2e-single": "DEBUG=price-finder* mocha --colors --reporter list $1"
+    "test-e2e-single": "DEBUG=price-finder* mocha --colors --reporter list --timeout 10000 $1"
   },
   "dependencies": {
     "accounting": "^0.4.0",

--- a/test/e2e/best-buy-uris-test.js
+++ b/test/e2e/best-buy-uris-test.js
@@ -71,7 +71,7 @@ describe('price-finder for Best Buy URIs', () => {
       it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
         priceFinder.findItemDetails(uri, (err, itemDetails) => {
           should(err).be.null();
-          verifyItemDetails(itemDetails, 'Ferris Bueller\'s Day Off (DVD) (Eng/Fre) 1986', 'Movies & TV');
+          verifyItemDetails(itemDetails, 'Ferris Bueller\'s Day Off (DVD)  (Eng/Fre)  1986', 'Movies & TV');
           done();
         });
       });

--- a/test/unit/sites/best-buy-test.js
+++ b/test/unit/sites/best-buy-test.js
@@ -80,11 +80,11 @@ describe('The Best Buy Site', () => {
 
         $ = cheerio.load(`
           <meta itemprop="price" content="${price}">
-          <div id="analytics-data"
-            data-uber-cat-name="Movies & Music"
-            data-parent-cat-name="Music (CDs & Vinyl): R&B & Soul">
-          </div>
           <div id="sku-title" itemprop="name">${name}</div>
+          <script>
+            track.uberCatName = "Movies & Music";foo = "bar";
+            track.parentCatName = "Music (CDs & Vinyl): R&B & Soul";bar = "baz";
+          </script>
         `);
         bad$ = cheerio.load('<h1>Nothin here</h1>');
       });


### PR DESCRIPTION
The analytics data which we used to locate the category for Best Buy (when scraping) has changed.  Update to use regex to pull the values from the new analytics data.

Also update the e2e test for Best Buy which had a name change.

This should fix #92.

Additionally, increase the timeout on the `test-e2e-single` script to 10 seconds (default was 2).