### PR TITLE
Fix flipkart

### DIFF
--- a/lib/sites/flipkart.js
+++ b/lib/sites/flipkart.js
@@ -21,8 +21,14 @@ class FlipkartSite {
   }
 
   findPriceOnPage($) {
-    // find the price on the page
-    const priceString = $('*[itemprop="price"]').attr('content');
+    // find the price on the page using regex!
+    // https://github.com/dylants/price-finder/issues/98
+    let priceString;
+    const regex = /Rs.\s*(\d+)/ig;
+    const results = regex.exec($('meta[name="Description"]').attr('content'));
+    if (results && results.length > 1) {
+      priceString = results[1];
+    }
 
     // were we successful?
     if (!priceString) {
@@ -47,7 +53,7 @@ class FlipkartSite {
 
   findNameOnPage($) {
     // find the name on the page
-    const name = $('*[itemprop="name"]').text().trim();
+    const name = $('title').text().trim();
 
     // were we successful?
     if (!name) {

--- a/test/e2e/flipkart-uris-test.js
+++ b/test/e2e/flipkart-uris-test.js
@@ -9,7 +9,7 @@ const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for Flipkart Store URIs', () => {
   describe('testing Nexus 6 item', () => {
-    const uri = 'http://www.flipkart.com/apple-iphone-6/p/itme8dvfeuxxbm4r?pid=MOBEYHZ2YAXZMF2J';
+    const uri = 'https://www.flipkart.com/apple-iphone-6/p/itme8dvfeuxxbm4r?pid=MOBEYHZ2YAXZMF2J';
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
@@ -22,7 +22,9 @@ describe('price-finder for Flipkart Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         should(err).be.null();
-        verifyItemDetails(itemDetails, 'Apple iPhone 6', 'Other');
+        verifyItemDetails(itemDetails,
+          'Apple iPhone 6 (Space Grey, 16 GB) | Buy Apple iPhone 6 (Space Grey, 16 GB) Mobile Phone Online at Best Price in India | Flipkart.com',
+          'Other');
         done();
       });
     });

--- a/test/unit/sites/flipkart-test.js
+++ b/test/unit/sites/flipkart-test.js
@@ -64,8 +64,8 @@ describe('The Flipkart Site', () => {
 
         // TODO provide content for unit test here!
         $ = cheerio.load(`
-          <h1 class="title" itemprop="name">${name}</h1>
-          <meta itemprop="price" content="24,999">
+          <title>${name}</title>
+          <meta name="Description" content="Buy this thing for Rs.24999 Online">
         `);
         bad$ = cheerio.load('<h1>Nothin here</h1>');
       });


### PR DESCRIPTION
Update flipkart to use regex instead of the `itemprop` meta tags (since the site has removed them).  More information about the problem can be found here:
https://github.com/dylants/price-finder/issues/98

This should close #98.