### PR TITLE
Defaults for no currency symbol, fix amazon video games

### DIFF
--- a/lib/site-utils.js
+++ b/lib/site-utils.js
@@ -97,9 +97,15 @@ exports.processPrice = function processPrice(priceStringInput) {
     logger.log('found inr in price, converting to number...');
     price = accounting.unformat(priceString);
   } else {
-    // unknown price type!!
-    logger.error('unknown price type, unable to process, returning -1');
-    price = -1;
+    // if no currency symbol was found, verify it is a number
+    logger.log('no currency symbol was found, verifying this is a number');
+    if (isNaN(priceString)) {
+      logger.log('price string is NOT a number, unable to process, returning -1');
+      price = -1;
+    } else {
+      logger.log('price string is a number, using defaults to convert...');
+      price = accounting.unformat(priceString);
+    }
   }
 
   logger.log('price (post-process): %s', price);

--- a/lib/sites/amazon.js
+++ b/lib/sites/amazon.js
@@ -24,11 +24,18 @@ class AmazonSite {
   findPriceOnPage($) {
     // the various ways we can find the price on an amazon page
     const selectors = [
+      // this specific selector was added to support new pages, that did NOT contain
+      // a decimal point in the price... so we're just grabbing the dollar amount (not cents)
+      // https://github.com/dylants/price-finder/issues/97
+      '#price #newPrice .buyingPrice',
+
       '#actualPriceValue',
       '#priceblock_ourprice',
       '#priceBlock .priceLarge',
+
       // Yes this is weird, but for some reason 'rentPrice' is the buy price
       '.buyNewOffers .rentPrice',
+
       '#buybox .a-color-price',
       '#buybox_feature_div .a-button-primary .a-text-bold',
       '#addToCart .header-price',

--- a/test/unit/site-utils-test.js
+++ b/test/unit/site-utils-test.js
@@ -134,8 +134,12 @@ describe('The Site Utils', () => {
       should(siteUtils.processPrice('INR 9,444')).equal(9444);
     });
 
-    it('should process an unknown price correctly', () => {
-      should(siteUtils.processPrice('hey, without symbol?')).equal(-1);
+    it('should process a price without a currency correctly', () => {
+      should(siteUtils.processPrice('35')).equal(35);
+    });
+
+    it('should process a non-price correctly', () => {
+      should(siteUtils.processPrice('no')).equal(-1);
     });
   });
 });


### PR DESCRIPTION
Finding the price for a video game at Amazon failed because they changed the page content to remove the decimal point from the price. To work around this, we’re now only finding the dollar price and not the cents price.  More information can be found in #97.

This has a side effect of no longer including the currency symbol in the price which we ask `site-utils` to process.  So update `site-utils` to check to see if the price string it gets is a number, and if so, use the defaults in `accounting` to process.  Otherwise, if it’s not a number, continue to return `-1`.

This should close #97. 