### PR TITLE
Add support for Target.com

### DIFF
--- a/lib/sites/target.js
+++ b/lib/sites/target.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const _ = require('lodash');
+const logger = require('../logger')();
+
+const API_URI = 'http://redsky.target.com/v1/pdp/tcin/';
+
+class TargetSite {
+  constructor(uri) {
+    if (!TargetSite.isSite(uri)) {
+      throw new Error('invalid uri for Target: %s', uri);
+    }
+
+    this._uri = uri;
+
+    // pull the product ID from the URI
+    const regex = /.*\/A-(\d+)$/ig;
+    const results = regex.exec(this._uri);
+    if (results && results.length > 1) {
+      this._apiUri = `${API_URI}${results[1]}`;
+    } else {
+      throw new Error('Unable to find product ID in Target URI: %s', uri);
+    }
+  }
+
+  getURIForPageData() {
+    return this._apiUri;
+  }
+
+  isJSON() {
+    return true;
+  }
+
+  findPriceOnPage(pageData) {
+    const price = _.get(pageData, 'product.price.offerPrice.price');
+
+    if (!price) {
+      logger.error('price not found on Target page, uri: %s', this._uri);
+      return -1;
+    }
+
+    return price;
+  }
+
+  findCategoryOnPage(pageData) {
+    const category = _.get(pageData, 'product.item.product_classification.item_type_name');
+
+    logger.log('category: %s', category);
+
+    return category;
+  }
+
+  findNameOnPage(pageData) {
+    const name = _.get(pageData, 'product.item.product_description.title');
+
+    // were we successful?
+    if (!name) {
+      logger.error('name not found on Target page, uri: %s', this._uri);
+      return null;
+    }
+
+    logger.log('name: %s', name);
+
+    return name;
+  }
+
+  static isSite(uri) {
+    if (uri.indexOf('www.target.com') > -1) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+
+module.exports = TargetSite;

--- a/test/e2e/target-uris-test.js
+++ b/test/e2e/target-uris-test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const should = require('should');
+const testHelper = require('./test-helper');
+
+const priceFinder = testHelper.priceFinder;
+const verifyPrice = testHelper.verifyPrice;
+const verifyItemDetails = testHelper.verifyItemDetails;
+
+describe('price-finder for Target Store URIs', () => {
+  describe('testing Video Game item', () => {
+    // Super Mario Maker Wii U
+    const uri = 'http://www.target.com/p/super-mario-maker-nintendo-wii-u/-/A-47904515';
+
+    it('should respond with a price for findItemPrice()', (done) => {
+      priceFinder.findItemPrice(uri, (err, price) => {
+        should(err).be.null();
+        verifyPrice(price);
+        done();
+      });
+    });
+
+    it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
+      priceFinder.findItemDetails(uri, (err, itemDetails) => {
+        should(err).be.null();
+        verifyItemDetails(itemDetails, 'Super Mario Maker (Nintendo Wii U)', 'Video Game - Console Games');
+        done();
+      });
+    });
+  });
+});

--- a/test/unit/sites/target-test.js
+++ b/test/unit/sites/target-test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const should = require('should');
+const TargetSite = require('../../../lib/sites/target');
+
+const PRODUCT_ID = '14404364';
+const VALID_URI = `http://www.target.com/123/product/A-${PRODUCT_ID}`;
+const BAD_URI = 'http://www.bad.com/123/product';
+const INVALID_URI = 'http://www.target.com/123/product';
+
+describe('The Target Site', () => {
+  it('should exist', () => {
+    should.exist(TargetSite);
+  });
+
+  describe('isSite() function', () => {
+    it('should return true for a correct site', () => {
+      should(TargetSite.isSite(VALID_URI)).be.true();
+    });
+
+    it('should return false for a bad site', () => {
+      should(TargetSite.isSite(BAD_URI)).be.false();
+    });
+  });
+
+  it('should throw an exception trying to create a new site with an bad uri', () => {
+    should.throws(() => {
+      /* eslint-disable no-new */
+      new TargetSite(BAD_URI);
+      /* eslint-enable no-new */
+    });
+  });
+
+  it('should throw an exception trying to create a new site with an invalid uri', () => {
+    should.throws(() => {
+      /* eslint-disable no-new */
+      new TargetSite(INVALID_URI);
+      /* eslint-enable no-new */
+    });
+  });
+
+  describe('a new Target Site', () => {
+    let site;
+
+    beforeEach(() => {
+      site = new TargetSite(VALID_URI);
+    });
+
+    it('should exist', () => {
+      should.exist(site);
+    });
+
+    it('should return the correct URI for getURIForPageData()', () => {
+      should(site.getURIForPageData()).equal(`http://redsky.target.com/v1/pdp/tcin/${PRODUCT_ID}`);
+    });
+
+    it('should return true for isJSON()', () => {
+      should(site.isJSON()).be.true();
+    });
+
+    describe('with a populated page', () => {
+      let pageData;
+      let badPageData;
+      let price;
+      let category;
+      let name;
+
+      beforeEach(() => {
+        price = 1.99;
+        category = 'Movies';
+        name = 'Some Product';
+
+        pageData = {
+          product: {
+            price: {
+              offerPrice: {
+                price,
+              },
+            },
+            item: {
+              product_classification: {
+                item_type_name: category,
+              },
+              product_description: {
+                title: name,
+              },
+            },
+          },
+        };
+
+        badPageData = {};
+      });
+
+      it('should return the price when displayed on the page', () => {
+        const priceFound = site.findPriceOnPage(pageData);
+        should(priceFound).equal(price);
+      });
+
+      it('should return -1 when the price is not found', () => {
+        const priceFound = site.findPriceOnPage(badPageData);
+        should(priceFound).equal(-1);
+      });
+
+      it('should always return the category', () => {
+        const categoryFound = site.findCategoryOnPage(pageData);
+        should(categoryFound).equal(category);
+      });
+
+      it('should return the name when displayed on the page', () => {
+        const nameFound = site.findNameOnPage(pageData, category);
+        should(nameFound).equal(name);
+      });
+
+      it('should return null when the name is not displayed on the page', () => {
+        const nameFound = site.findNameOnPage(badPageData, category);
+        should(nameFound).be.null();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add support for target.com, using the API call rather than the page scrape.  This provides us with more detail than a page scrape, specifically within the categories call, which is simply returning what Target specifies.

This should close #79.