### PR TITLE
Flipkart problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ The current supported sites are listed below.
    [Best Buy developer documentation](https://developer.bestbuy.com).
 - Crutchfield
 - eBags
-- Flipkart
 - GameStop
 - GOG
 - Google Play

--- a/test/e2e/flipkart-uris-test.js
+++ b/test/e2e/flipkart-uris-test.js
@@ -7,7 +7,13 @@ const priceFinder = testHelper.priceFinder;
 const verifyPrice = testHelper.verifyPrice;
 const verifyItemDetails = testHelper.verifyItemDetails;
 
-describe('price-finder for Flipkart Store URIs', () => {
+/*
+ * TODO Skip the tests until we can work out Flipkart's problems
+ * See:
+ * https://github.com/dylants/price-finder/issues/98
+ * https://github.com/dylants/price-finder/issues/106
+ */
+describe.skip('price-finder for Flipkart Store URIs', () => {
   describe('testing Nexus 6 item', () => {
     const uri = 'https://www.flipkart.com/apple-iphone-6/p/itme8dvfeuxxbm4r?pid=MOBEYHZ2YAXZMF2J';
 

--- a/test/e2e/snapdeal-uris-test.js
+++ b/test/e2e/snapdeal-uris-test.js
@@ -9,7 +9,7 @@ const verifyItemDetails = testHelper.verifyItemDetails;
 
 describe('price-finder for Snapdeal Store URIs', () => {
   describe('testing item', () => {
-    const uri = 'http://www.snapdeal.com/product/iphone-6s-16gb/663413326062';
+    const uri = 'https://www.snapdeal.com/product/apple-iphone-7-32gb-gold/626098478748';
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
@@ -22,7 +22,7 @@ describe('price-finder for Snapdeal Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         should(err).be.null();
-        verifyItemDetails(itemDetails, 'iPhone 6s (16GB)', 'Mobile Phones');
+        verifyItemDetails(itemDetails, '\n   \t\t\tApple iPhone 7 32GB', 'Mobile Phones');
         done();
       });
     });


### PR DESCRIPTION
At this point we’re unable to get the price from a Flipkart site.  For more information on the problem, see:
https://github.com/dylants/price-finder/issues/98
https://github.com/dylants/price-finder/issues/106
    
So for now, we’re going to state we do NOT support Flipkart, though we’re leaving in the code until we can determine if we should remove it or try to add support back in.

Also, fix a Snapdeal e2e test.

This "kinda" fixes #106.