### PR TITLE
Amazon fixes, e2e fixes

### DIFF
--- a/lib/sites/amazon.js
+++ b/lib/sites/amazon.js
@@ -24,22 +24,32 @@ class AmazonSite {
   findPriceOnPage($) {
     // the various ways we can find the price on an amazon page
     const selectors = [
+      // used in amazon fashion, home audio and video, and when sale price not in buy box
+      '#priceblock_saleprice',
+
       // this specific selector was added to support new pages, that did NOT contain
       // a decimal point in the price... so we're just grabbing the dollar amount (not cents)
       // https://github.com/dylants/price-finder/issues/97
+      // used in (at least) video games
       '#price #newPrice .buyingPrice',
 
+      // used in (at least) mobile apps
       '#actualPriceValue',
+
+      // used in electronics, subscription items (without subscription)
       '#priceblock_ourprice',
-      '#priceBlock .priceLarge',
 
-      // Yes this is weird, but for some reason 'rentPrice' is the buy price
-      '.buyNewOffers .rentPrice',
-
+      // used in CDs, DVDs, tools and home improvement, household items
       '#buybox .a-color-price',
+
+      // used in (at least) digital music
       '#buybox_feature_div .a-button-primary .a-text-bold',
+
+      // used in (at least) books
       '#addToCart .header-price',
-      '#priceblock_saleprice',
+
+      // used when amazon is NOT showing their price, to instead look at other seller's price
+      '#moreBuyingChoices_feature_div .a-color-price',
     ];
 
     // find the price on the page

--- a/lib/sites/newegg.js
+++ b/lib/sites/newegg.js
@@ -34,7 +34,7 @@ class NewEggSite {
     priceString = $("*[itemprop='price']").attr('content');
     if (!priceString) {
       // try the regex path!
-      const regex = /product_sale_price:\['(.*)'\]/ig;
+      const regex = /product_sale_price:\['(.*)'\]/ig; // eslint-disable-line no-useless-escape
       const results = regex.exec($.html());
       if (results && results.length > 1) {
         priceString = results[1];

--- a/test/e2e/amazon-uris-test.js
+++ b/test/e2e/amazon-uris-test.js
@@ -62,7 +62,7 @@ describe('price-finder for Amazon URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         should(err).be.null();
-        verifyItemDetails(itemDetails, 'Minecraft - Pocket Edition', 'Mobile Apps');
+        verifyItemDetails(itemDetails, 'Minecraft: Pocket Edition', 'Mobile Apps');
         done();
       });
     });

--- a/test/e2e/crutchfield-uris-test.js
+++ b/test/e2e/crutchfield-uris-test.js
@@ -32,8 +32,8 @@ describe('price-finder for Crutchfield Store URIs', () => {
 
   // Home Audio
   describe('testing a Home Audio item', () => {
-    // Marantz Receiver
-    const uri = 'http://www.crutchfield.com/p_642NR1504/Marantz-NR1504.html';
+    // Sony Receiver
+    const uri = 'http://www.crutchfield.com/p_158STDH770/Sony-STR-DH770.html?tp=179';
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
@@ -46,7 +46,7 @@ describe('price-finder for Crutchfield Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         should(err).be.null();
-        verifyItemDetails(itemDetails, 'Marantz NR1504', 'Home Audio');
+        verifyItemDetails(itemDetails, 'Sony STR-DH770', 'Home Audio');
         done();
       });
     });

--- a/test/e2e/snapdeal-uris-test.js
+++ b/test/e2e/snapdeal-uris-test.js
@@ -22,7 +22,7 @@ describe('price-finder for Snapdeal Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         should(err).be.null();
-        verifyItemDetails(itemDetails, '\n   \t\t\tApple iPhone 7 32GB', 'Mobile Phones');
+        verifyItemDetails(itemDetails, '\n   \t\t\tApple iPhone 7 (32GB)', 'Mobile Phones');
         done();
       });
     });


### PR DESCRIPTION
We’ve collected a list of selectors to use for Amazon products. Go through that list, trim it down if possible, and label where each selector is used (at least one place).

In addition to cleaning up the selectors, try to fix a couple issues:
- Use the “more buying options” price when Amazon doesn’t list the price or doesn’t sell it themselves. This should close #112.
- The second issue is when Amazon has a sale price but doesn’t list it in the buy box. Move up the sale price selector higher in the select order to correctly grab it rather than some other price listed in the buy box (insurance, warranty, etc). This should close #113.

Also fix some end to end tests which require changes because of product changes on these sites. And disable an eslint rule within a regex line of code, since it was causing problems and was necessary for the regex.