### PR TITLE
Fix sites, update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ env:
   # We want to run both (unit) tests and end to end tests as a matrix
   # https://docs.travis-ci.com/user/speeding-up-the-build/#Parallelizing-your-builds-across-virtual-machines
   - TEST_SUITE=test
-  - TEST_SUITE=test-e2e
+  # Disable the end to end tests in CI, since the CI boxes seem to be blocked by some sites at the
+  # moment. Going to have to run these locally for now to verify the behavior still works. Hope the
+  # CI boxes are unblocked at some point in the future.
+  # - TEST_SUITE=test-e2e
 language: node_js
 node_js:
   - "8"

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ $ DEBUG=price-finder* node app.js
 The current supported sites are listed below.
 
 - Amazon
-- Best Buy
+- Best Buy (\*)
   - API support is available but requires an API key.  To enable, set the
    `BESTBUY_KEY` environment variable to the value of the API key. For more
    information on how to obtain an API key, refer to the
@@ -131,17 +131,19 @@ The current supported sites are listed below.
 - GameStop
 - GOG
 - Google Play
-- Greenman Gaming
-- Infibeam
+- Greenman Gaming (\*)
+- Infibeam (\*)
 - Newegg
 - Nintendo
-- PriceMinister
+- PriceMinister (\*)
 - Snapdeal
 - Sony Playstation
 - Steam
 - Target
 - Thinkgeek
 - Walmart
+
+(\*Support unknown at this time)
 
 Don't see your site listed? Please consider [contributing](#contributing) to
 the project!

--- a/lib/price-finder.js
+++ b/lib/price-finder.js
@@ -153,7 +153,7 @@ class PriceFinder {
       // hit the site to get the item details
       (whilstCallback) => {
         logger.log('scraping uri: %s', site.getURIForPageData());
-        request.get(site.getURIForPageData()).end((err, response) => {
+        request.get(site.getURIForPageData()).set('User-Agent', 'Mozilla').end((err, response) => {
           if (err) {
             return whilstCallback(err);
           }

--- a/lib/site-utils.js
+++ b/lib/site-utils.js
@@ -47,11 +47,14 @@ exports.findContentOnPage = function findContentOnPage($, selectors) {
       logger.log('found content with selector: %s', selectors[i]);
 
       // if it's an array, return the first element
-      if (content.length) {
+      if (content.length && content.length > 1) {
         logger.log('content is an array, attempting to return first entry');
         return jQuery(selectors[i]).first().text().trim();
-      } else {
+      } else if (_.isFunction(content.text) && content.text().trim()) {
+        // if we have text, return it
         return content.text().trim();
+      } else {
+        // nothing here, keep looking
       }
     }
   }

--- a/lib/sites/amazon.js
+++ b/lib/sites/amazon.js
@@ -111,7 +111,7 @@ class AmazonSite {
     if (category === siteUtils.categories.DIGITAL_MUSIC) {
       /* eslint-disable prefer-template */
       name = $('#ArtistLinkSection').text().trim() + ': '
-        + $('#title_feature_div').text().trim();
+        + $('#dmusicProductTitle_feature_div').text().trim();
       /* eslint-enable prefer-template */
     } else {
       const selectors = [

--- a/lib/sites/gog.js
+++ b/lib/sites/gog.js
@@ -21,7 +21,11 @@ class GogSite {
   }
 
   findPriceOnPage($) {
-    const priceString = $("*[itemprop='price']").attr('content');
+    const selectors = [
+      '.product-actions-price__final-amount._price',
+    ];
+
+    const priceString = siteUtils.findContentOnPage($, selectors);
 
     if (!priceString) {
       logger.error('price not found on Gog page, uri: %s', this._uri);
@@ -43,7 +47,7 @@ class GogSite {
   }
 
   findNameOnPage($) {
-    const name = $('*[itemprop="name"]').text();
+    const name = $('.productcard-basics__title').text();
 
     if (!name) {
       logger.error('name not found on Gog page, uri: %s', this._uri);

--- a/lib/sites/google-play.js
+++ b/lib/sites/google-play.js
@@ -62,7 +62,7 @@ class GooglePlaySite {
   }
 
   findNameOnPage($) {
-    let name = $('.details-info .document-title').text();
+    let name = $('h1[itemprop="name"]').text();
     if (!name || name.length < 1) {
       logger.error('name not found on google play page, uri: %s', this._uri);
       return null;

--- a/lib/sites/nintendo.js
+++ b/lib/sites/nintendo.js
@@ -24,6 +24,7 @@ class NintendoSite {
 
   findPriceOnPage($) {
     const selectors = [
+      '#purchase-options .sale-price',
       '#purchase-options .msrp',
     ];
 

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   },
   "dependencies": {
     "accounting": "0.4.1",
-    "async": "2.6.1",
+    "async": "2.6.2",
     "cheerio": "0.22.0",
     "debug-caller": "2.2.0",
-    "lodash": "4.17.10",
-    "superagent": "3.8.3",
+    "lodash": "4.17.11",
+    "superagent": "4.1.0",
     "xtend": "4.0.1"
   },
   "devDependencies": {

--- a/test/e2e/amazon-uris-test.js
+++ b/test/e2e/amazon-uris-test.js
@@ -104,7 +104,7 @@ describe('price-finder for Amazon URIs', () => {
         should(err).be.null();
 
         // Amazon reports 'apparel' for luggage, so we default to 'other'
-        verifyItemDetails(itemDetails, 'eBags TLS Mother Lode Mini 21" Wheeled Duffel', 'Other');
+        verifyItemDetails(itemDetails, 'eBags TLS Mother Lode Mini 21" Wheeled Duffel Bag Luggage - Carry-On - (Blue Yonder)', 'Other');
         done();
       });
     });

--- a/test/e2e/best-buy-uris-test.js
+++ b/test/e2e/best-buy-uris-test.js
@@ -24,7 +24,7 @@ describe('price-finder for Best Buy URIs', () => {
       // Blues Brothers: Briefcase Full of Blues
       const uri = 'https://www.bestbuy.com/site/briefcase-full-of-blues-cd/17112312.p?id=1889657&skuId=17112312';
 
-      it('should respond with a price for findItemPrice()', (done) => {
+      xit('should respond with a price for findItemPrice()', (done) => {
         priceFinder.findItemPrice(uri, (err, price) => {
           should(err).be.null();
           verifyPrice(price);
@@ -32,7 +32,7 @@ describe('price-finder for Best Buy URIs', () => {
         });
       });
 
-      it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
+      xit('should respond with a price, and the right category and name for findItemDetails()', (done) => {
         priceFinder.findItemDetails(uri, (err, itemDetails) => {
           should(err).be.null();
           verifyItemDetails(itemDetails, 'Briefcase Full of Blues [CD]', 'Music');
@@ -58,7 +58,7 @@ describe('price-finder for Best Buy URIs', () => {
       // Legend of Zelda
       const uri = 'https://www.bestbuy.com/site/the-legend-of-zelda-breath-of-the-wild-nintendo-switch/5721500.p?skuId=5721500';
 
-      it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
+      xit('should respond with a price, and the right category and name for findItemDetails()', (done) => {
         priceFinder.findItemDetails(uri, (err, itemDetails) => {
           should(err).be.null();
           verifyItemDetails(itemDetails, 'The Legend of Zelda: Breath of the Wild - Nintendo Switch', 'Video Games');

--- a/test/e2e/crutchfield-uris-test.js
+++ b/test/e2e/crutchfield-uris-test.js
@@ -6,10 +6,9 @@ const testHelper = require('./test-helper');
 const { priceFinder, verifyPrice, verifyItemDetails } = testHelper;
 
 describe('price-finder for Crutchfield Store URIs', () => {
-  // Television & Video
-  describe('testing a Television & Video item', () => {
-    // Samsung Blu-ray Player
-    const uri = 'https://www.crutchfield.com/p_305BDJ5700/Samsung-BD-J5700.html';
+  describe('testing an item', () => {
+    // Sony Blu-ray Player
+    const uri = 'https://www.crutchfield.com/p_158BDP3700/Sony-BDP-S3700.html';
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {
@@ -22,29 +21,7 @@ describe('price-finder for Crutchfield Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         should(err).be.null();
-        verifyItemDetails(itemDetails, 'Samsung BD-J5700', 'Television & Video');
-        done();
-      });
-    });
-  });
-
-  // Home Audio
-  describe('testing a Home Audio item', () => {
-    // Sony Receiver
-    const uri = 'https://www.crutchfield.com/p_158STDH790/Sony-STR-DH790.html';
-
-    it('should respond with a price for findItemPrice()', (done) => {
-      priceFinder.findItemPrice(uri, (err, price) => {
-        should(err).be.null();
-        verifyPrice(price);
-        done();
-      });
-    });
-
-    it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
-      priceFinder.findItemDetails(uri, (err, itemDetails) => {
-        should(err).be.null();
-        verifyItemDetails(itemDetails, 'Sony STR-DH790', 'Home Audio');
+        verifyItemDetails(itemDetails, 'Sony BDP-S3700', 'Television & Video');
         done();
       });
     });

--- a/test/e2e/gamestop-uris-test.js
+++ b/test/e2e/gamestop-uris-test.js
@@ -9,7 +9,7 @@ describe('price-finder for GameStop Store URIs', () => {
   // Video Games
   describe('testing a Video Game item', () => {
     // Mario Kart 8
-    const uri = 'http://www.gamestop.com/wii-u/games/mario-kart-8/113373';
+    const uri = 'https://www.gamestop.com/wii-u/games/mario-kart-8/113373';
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {

--- a/test/e2e/gog-uris-test.js
+++ b/test/e2e/gog-uris-test.js
@@ -8,7 +8,7 @@ const { priceFinder, verifyPrice, verifyItemDetails } = testHelper;
 describe('price-finder for Gog Store URIs', () => {
   describe('testing an item', () => {
     // Don't Starve
-    const uri = 'http://www.gog.com/game/dont_starve';
+    const uri = 'https://www.gog.com/game/dont_starve';
 
     it('should respond with a price for findItemPrice()', (done) => {
       priceFinder.findItemPrice(uri, (err, price) => {

--- a/test/e2e/walmart-uris-test.js
+++ b/test/e2e/walmart-uris-test.js
@@ -20,7 +20,7 @@ describe('price-finder for Walmart Store URIs', () => {
     it('should respond with a price, and the right category and name for findItemDetails()', (done) => {
       priceFinder.findItemDetails(uri, (err, itemDetails) => {
         should(err).be.null();
-        verifyItemDetails(itemDetails, 'Intel Core i5-4690K Processor', 'Other');
+        verifyItemDetails(itemDetails, 'Intel Core i5-4690K Processor', 'Electronics');
         done();
       });
     });

--- a/test/unit/price-finder-test.js
+++ b/test/unit/price-finder-test.js
@@ -59,6 +59,9 @@ describe('PriceFinder', () => {
         get() {
           return this;
         },
+        set() {
+          return this;
+        },
 
         end(callback) {
           // setup valid response
@@ -109,6 +112,9 @@ describe('PriceFinder', () => {
         get() {
           return this;
         },
+        set() {
+          return this;
+        },
 
         end(callback) {
           // setup invalid response code
@@ -146,6 +152,9 @@ describe('PriceFinder', () => {
       // set request to return a specific body
       const request = {
         get() {
+          return this;
+        },
+        set() {
           return this;
         },
 

--- a/test/unit/sites/gog-test.js
+++ b/test/unit/sites/gog-test.js
@@ -63,8 +63,8 @@ describe('The Gog Site', () => {
         name = 'Some Product';
 
         $ = cheerio.load(`
-          <h1 class="header__title" itemprop="name">${name}</h1>
-          <meta itemprop="price" content="${price}">
+          <div class="productcard-basics__title">${name}</div>
+          <div class="product-actions-price__final-amount _price">${price}"</div>
         `);
         bad$ = cheerio.load('<h1>Nothin here</h1>');
       });

--- a/test/unit/sites/google-play-test.js
+++ b/test/unit/sites/google-play-test.js
@@ -65,8 +65,7 @@ describe('The GooglePlay Site', () => {
         $ = cheerio.load(
           `<title>Big - Movies & TV on Google Play</title>
            <meta content="$${price}" itemprop="price">
-           <div class='details-info'>
-           <div class='document-title'>Big</div></div>`,
+           <h1 itemprop="name">${name}</h1>`,
         );
         bad$ = cheerio.load('<h1>Nothin here</h1>');
       });

--- a/test/unit/sites/nintendo-test.js
+++ b/test/unit/sites/nintendo-test.js
@@ -95,6 +95,21 @@ describe('The Nintendo Site', () => {
         const nameFound = nintendo.findNameOnPage(bad$);
         should(nameFound).be.null();
       });
+
+      it('should return the sale price when available', () => {
+        const salePrice = 49.99;
+        $ = cheerio.load(
+          `<span id='purchase-options'>
+             <div class="price discounted loaded" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+               <span class="sale-price">$${salePrice}</span>
+               <span class="msrp">$${price}</span>
+             </div>
+           </span>`,
+        );
+
+        const priceFound = nintendo.findPriceOnPage($);
+        should(priceFound).equal(salePrice);
+      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,11 +106,11 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-async@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
+async@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
   dependencies:
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 async@~1.5.2:
   version "1.5.2"
@@ -259,9 +259,9 @@ colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
-combined-stream@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+combined-stream@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -290,7 +290,7 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
-cookiejar@^2.1.0:
+cookiejar@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
 
@@ -361,6 +361,12 @@ debug@^2.1.3, debug@^2.6.8, debug@^2.6.9:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
+
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.1.2:
   version "1.2.0"
@@ -677,10 +683,6 @@ exit@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
 
-extend@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
-
 external-editor@^2.0.4, external-editor@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
@@ -757,12 +759,12 @@ foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
-form-data@^2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
+form-data@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "1.0.6"
+    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 formidable@^1.2.0:
@@ -1241,7 +1243,11 @@ lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
 
-lodash@4.17.10, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10, lodash@~4.17.5:
+lodash@4.17.11, lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
+lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.10, lodash@~4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -1300,9 +1306,9 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "~1.33.0"
 
-mime@^1.4.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+mime@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -1351,6 +1357,10 @@ module-not-found-error@^1.0.0:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
 multimatch@^2.0.0:
   version "2.1.0"
@@ -1571,9 +1581,9 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
-qs@^6.5.1:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+qs@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -1605,7 +1615,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@^2.3.5:
+readable-stream@^2.0.2, readable-stream@^2.2.2:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -1616,6 +1626,14 @@ readable-stream@^2.0.2, readable-stream@^2.2.2, readable-stream@^2.3.5:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@^3.0.6:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.2.0.tgz#de17f229864c120a9f56945756e4f32c4045245d"
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -1829,6 +1847,12 @@ string.prototype.matchall@^2.0.0:
     has-symbols "^1.0.0"
     regexp.prototype.flags "^1.2.0"
 
+string_decoder@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
+  dependencies:
+    safe-buffer "~5.1.0"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -1867,20 +1891,19 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-superagent@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+superagent@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-4.1.0.tgz#c465c2de41df2b8d05c165cbe403e280790cdfd5"
   dependencies:
     component-emitter "^1.2.0"
-    cookiejar "^2.1.0"
-    debug "^3.1.0"
-    extend "^3.0.0"
-    form-data "^2.3.1"
+    cookiejar "^2.1.2"
+    debug "^4.1.0"
+    form-data "^2.3.3"
     formidable "^1.2.0"
     methods "^1.1.1"
-    mime "^1.4.1"
-    qs "^6.5.1"
-    readable-stream "^2.3.5"
+    mime "^2.4.0"
+    qs "^6.6.0"
+    readable-stream "^3.0.6"
 
 supports-color@5.4.0, supports-color@^5.3.0:
   version "5.4.0"
@@ -1959,7 +1982,7 @@ uri-js@^4.2.1:
   dependencies:
     punycode "^2.1.0"
 
-util-deprecate@^1.0.2, util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 


### PR DESCRIPTION
**Fix sites**
- Some sites have changed which require updates. Also fix some of the e2e tests to account for product updates.
- Add a request header (User-Agent) to the main call to allow some sites to work.

**Temporarily Disable Site**
- Best Buy looks to have disabled the ability to scrape the site, so temporarily disable the e2e tests. Support is unknown at this time.

**Update dependencies**
- Update the dependencies to latest.

**e2e in CI**
- Disable the e2e tests in CI while the CI boxes are blocked by some sites. Hope to enable it back in the future, but running it locally to verify e2e works for now.