### PR TITLE
Amazon fixes

### DIFF
--- a/lib/sites/amazon.js
+++ b/lib/sites/amazon.js
@@ -72,32 +72,49 @@ class AmazonSite {
   }
 
   findCategoryOnPage($) {
-    const amazonCategory = $('#nav-subnav').data('category');
+    // first check for #nav-subnav
+    let amazonCategory = $('#nav-subnav').data('category');
+
     if (!amazonCategory || amazonCategory.length < 1) {
-      logger.error('category not found on amazon page, uri: %s', this._uri);
-      return null;
+      // other ways we can find the category on an amazon page
+      const selectors = [
+        // this specific selector is added to support pages, that did NOT contain
+        // data-category attribute in #nav-subnav selector, e.g.
+        // https://www.amazon.com/SHUX-DualShock-Wireless-Controller-Playstation/dp/B07KW67PFX
+        // used in (at-least) Video Games
+        '#wayfinding-breadcrumbs_container ul li span a',
+      ];
+
+      // find the category on the page
+      amazonCategory = siteUtils.findContentOnPage($, selectors);
+
+      // were we successful?
+      if (!amazonCategory || amazonCategory.length < 1 || amazonCategory === 'Back to results') {
+        logger.error('category not found on amazon page, uri: %s', this._uri);
+        return null;
+      }
     }
 
     let category;
-    if (amazonCategory === 'dmusic') {
+    if (amazonCategory === 'dmusic' || amazonCategory === 'Digital Music') {
       category = siteUtils.categories.DIGITAL_MUSIC;
-    } else if (amazonCategory === 'videogames') {
+    } else if (amazonCategory === 'videogames' || amazonCategory === 'Video Games') {
       category = siteUtils.categories.VIDEO_GAMES;
-    } else if (amazonCategory === 'mobile-apps') {
+    } else if (amazonCategory === 'mobile-apps' || amazonCategory === 'Mobile Apps') {
       category = siteUtils.categories.MOBILE_APPS;
-    } else if (amazonCategory === 'movies-tv') {
+    } else if (amazonCategory === 'movies-tv' || amazonCategory === 'Movies & TV') {
       category = siteUtils.categories.MOVIES_TV;
-    } else if (amazonCategory === 'photo') {
+    } else if (amazonCategory === 'photo' || amazonCategory === 'Camera & Video') {
       category = siteUtils.categories.CAMERA_VIDEO;
-    } else if (amazonCategory === 'toys-and-games') {
+    } else if (amazonCategory === 'toys-and-games' || amazonCategory === 'Toys & Games') {
       category = siteUtils.categories.TOYS_GAMES;
-    } else if (amazonCategory === 'shared-fiona-attributes') {
+    } else if (amazonCategory === 'shared-fiona-attributes' || amazonCategory === 'Kindle Books') {
       category = siteUtils.categories.KINDLE_BOOKS;
-    } else if (amazonCategory === 'books') {
+    } else if (amazonCategory === 'books' || amazonCategory === 'Books') {
       category = siteUtils.categories.BOOKS;
-    } else if (amazonCategory === 'hi') {
+    } else if (amazonCategory === 'hi' || amazonCategory === 'Household') {
       category = siteUtils.categories.HOUSEHOLD;
-    } else if (amazonCategory === 'hpc') {
+    } else if (amazonCategory === 'hpc' || amazonCategory === 'Health & Personal Care') {
       category = siteUtils.categories.HEALTH_PERSONAL_CARE;
     } else {
       logger.log('category not setup, using "other"');

--- a/lib/sites/amazon.js
+++ b/lib/sites/amazon.js
@@ -27,11 +27,12 @@ class AmazonSite {
       // used in amazon fashion, home audio and video, and when sale price not in buy box
       '#priceblock_saleprice',
 
-      // this specific selector was added to support new pages, that did NOT contain
+      // these specific selectors were added to support new pages, that did NOT contain
       // a decimal point in the price... so we're just grabbing the dollar amount (not cents)
       // https://github.com/dylants/price-finder/issues/97
       // used in (at least) video games
       '#price #newPrice .buyingPrice',
+      '#price #newPitchPrice .price-large',
 
       // used in (at least) mobile apps
       '#actualPriceValue',
@@ -51,8 +52,9 @@ class AmazonSite {
       // used when amazon is NOT showing their price, to instead look at other seller's price
       '#moreBuyingChoices_feature_div .a-color-price',
 
-      // used in (at least) video games, when #newPrice is empty
+      // used in (at least) video games, when new price is NOT available
       '#price #usedPrice .buyingPrice',
+      '#price #usedPitchPrice .price-large',
     ];
 
     // find the price on the page

--- a/lib/sites/amazon.js
+++ b/lib/sites/amazon.js
@@ -50,6 +50,9 @@ class AmazonSite {
 
       // used when amazon is NOT showing their price, to instead look at other seller's price
       '#moreBuyingChoices_feature_div .a-color-price',
+
+      // used in (at least) video games, when #newPrice is empty
+      '#price #usedPrice .buyingPrice',
     ];
 
     // find the price on the page

--- a/test/unit/sites/amazon-test.js
+++ b/test/unit/sites/amazon-test.js
@@ -78,7 +78,14 @@ describe('The Amazon Site', () => {
         should(priceFound).equal(-1);
       });
 
-      it('should return the category when displayed on the page', () => {
+      it('should return the category when displayed on the page, in data-category', () => {
+        const categoryFound = amazon.findCategoryOnPage($);
+        should(categoryFound).equal(category);
+      });
+
+      it('should return the category when displayed on the page, in breadcrums', () => {
+        $ = cheerio.load(`<div id="wayfinding-breadcrumbs_container">
+          <ul><li><span><a>Books</a></span></li></ul></div>`);
         const categoryFound = amazon.findCategoryOnPage($);
         should(categoryFound).equal(category);
       });


### PR DESCRIPTION
~~**Price**~~

- ~~Look in `#usedPrice`, when `#newPrice` is empty and none other selector has price.~~
_Amazon changed the selectors, a day after this commit. Check last commit_

**Category**

- Look in `#wayfinding-breadcrumbs_container ul li span a`, when `data-category` attribute is absent.
e.g. https://www.amazon.com/product/dp/B001AQO446
_Fixes e2e tests_, `testing a Movies & TV item` and `testing a Luggage item`

**Unit Test**

- Write a unit test, `should return the category when displayed on the page, in breadcrums`

**Tweak Price Selectors**

- Amazon has changed how it displays price, for Video Games. Replacing `#newPrice .buyingPrice` with `#newPitchPrice .price-large`, and likewise `#usedPrice .buyingPrice` with `#usedPitchPrice .price-large`.
e.g. https://www.amazon.com/Pikmin-3-Nintendo-Wii-U/dp/B0050SWBAE
_Fixes e2e test_, `testing a Video Games item`